### PR TITLE
Rework snippets to remove language competition

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md)
 * Make any changes you wish
 * `npm test` or use the [Extension Test Runner](https://marketplace.visualstudio.com/items?itemName=ms-vscode.extension-test-runner)
 
+
 ## 🔗 Links
 
 * [VSCode Marketplace - ABLUnit Test Runner](https://marketplace.visualstudio.com/items?itemName=kherring.ablunit-test-provider)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md)
 * Make any changes you wish
 * `npm test` or use the [Extension Test Runner](https://marketplace.visualstudio.com/items?itemName=ms-vscode.extension-test-runner)
 
-
 ## 🔗 Links
 
 * [VSCode Marketplace - ABLUnit Test Runner](https://marketplace.visualstudio.com/items?itemName=kherring.ablunit-test-provider)

--- a/package.json
+++ b/package.json
@@ -167,24 +167,9 @@
 		},
 		"languages": [
 			{
-				"id": "abl-procedure",
-				"extensions": [
-					".p"
-				]
-			},
-			{
-				"id": "abl-class",
-				"extensions": [
-					".cls"
-				]
-			},
-			{
 				"id": "jsonc",
-				"filenames": [
-					"ablunit-test-profile.json"
-				],
 				"filenamePatterns": [
-					"ablunit-test-profile.*.json"
+					"**/ablunit-test-profile*.json"
 				]
 			}
 		],
@@ -198,12 +183,16 @@
 		],
 		"snippets": [
 			{
-				"language": "abl-procedure",
-				"path": "./snippets-procedures.json"
+				"language": "abl",
+				"path": "./snippets-abl.json"
 			},
 			{
-				"language": "abl-class",
-				"path": "./snippets-classes.json"
+				"language": "abl",
+				"path": "./snippets-procedurs.json"
+			},
+			{
+				"language": "abl",
+				"path": "./snippets-class.json"
 			}
 		]
 	}

--- a/snippets-abl-class.json
+++ b/snippets-abl-class.json
@@ -1,36 +1,4 @@
 {
-	"block-level on error undo, throw.": {
-		"prefix": "block-level on error undo, throw.",
-		"body": [
-			"block-level on error undo, throw."
-		],
-		"scope": "abl-class"
-	},
-	"routing-level on error undo, throw.": {
-		"prefix": "routine-level on error undo, throw.",
-		"body": "routine-level on error undo, throw.",
-		"scope": "abl-class"
-	},
-	"using OpenEdge.Core.Assert.":{
-		"prefix": "using OpenEdge.Core.Assert.",
-		"body": "using OpenEdge.Core.Assert.",
-		"scope": "abl-class"
-	},
-	"@Ignore": {
-		"prefix": "@Ignore",
-		"body": [
-			"@Ignore"
-		],
-		"description": "Ignores the test. You can use this annotation when you are still working on a code, the test case is not ready to run, or if the execution time of test is too long to be included.",
-		"scope": "abl-class"
-	},
-	"@Testsuite": {
-		"prefix": "@Testsuite",
-		"body": "@Testsuite(classes=\"${1:classList}\", procedures=\"${2:procedureList}\")",
-		"description": "Identifies that the suite of test procedures or test methods is a test suite.",
-		"scope": "abl-class"
-	},
-
 	"@Test method": {
 		"prefix": "@Test method",
 		"body": [

--- a/snippets-abl-procedure.json
+++ b/snippets-abl-procedure.json
@@ -1,36 +1,4 @@
 {
-	"block-level on error undo, throw.": {
-		"prefix": "block-level on error undo, throw.",
-		"body": [
-			"block-level on error undo, throw."
-		],
-		"scope": "abl-procedure"
-	},
-	"routing-level on error undo, throw.": {
-		"prefix": "routine-level on error undo, throw.",
-		"body": "routine-level on error undo, throw.",
-		"scope": "abl-procedure"
-	},
-	"using OpenEdge.Core.Assert.":{
-		"prefix": "using OpenEdge.Core.Assert.",
-		"body": "using OpenEdge.Core.Assert.",
-		"scope": "abl-procedure"
-	},
-	"@Ignore": {
-		"prefix": "@Ignore",
-		"body": [
-			"@Ignore"
-		],
-		"description": "Ignores the test. You can use this annotation when you are still working on a code, the test case is not ready to run, or if the execution time of test is too long to be included.",
-		"scope": "abl-procedure"
-	},
-	"@Testsuite": {
-		"prefix": "@Testsuite",
-		"body": "@Testsuite(classes=\"${1:classList}\", procedures=\"${2:procedureList}\")",
-		"description": "Identifies that the suite of test procedures or test methods is a test suite.",
-		"scope": "abl-procedure"
-	},
-
 	"@Test procedure": {
 		"prefix": "@Test procedure",
 		"body": [

--- a/snippets-abl.json
+++ b/snippets-abl.json
@@ -1,0 +1,33 @@
+{
+	"block-level on error undo, throw.": {
+		"prefix": "block-level on error undo, throw.",
+		"body": [
+			"block-level on error undo, throw."
+		],
+		"scope": "abl-class"
+	},
+	"routing-level on error undo, throw.": {
+		"prefix": "routine-level on error undo, throw.",
+		"body": "routine-level on error undo, throw.",
+		"scope": "abl-class"
+	},
+	"using OpenEdge.Core.Assert.":{
+		"prefix": "using OpenEdge.Core.Assert.",
+		"body": "using OpenEdge.Core.Assert.",
+		"scope": "abl-class"
+	},
+	"@Ignore": {
+		"prefix": "@Ignore",
+		"body": [
+			"@Ignore"
+		],
+		"description": "Ignores the test. You can use this annotation when you are still working on a code, the test case is not ready to run, or if the execution time of test is too long to be included.",
+		"scope": "abl-class"
+	},
+	"@Testsuite": {
+		"prefix": "@Testsuite",
+		"body": "@Testsuite(classes=\"${1:classList}\", procedures=\"${2:procedureList}\")",
+		"description": "Identifies that the suite of test procedures or test methods is a test suite.",
+		"scope": "abl-class"
+	}
+}


### PR DESCRIPTION
Rework snippets so they don't cause competition with the language provided by [vscode-abl](https://github.com/vscode-abl/vscode-abl).

I'd like to show the methods only on classes and procedures only in `.p` files.  This would require an update to [chriscamicas/abl-tmLanguage](https://github.com/chriscamicas/abl-tmlanguage) to have separate scopes for each.  I will try to make happen for a future release.