### PR TITLE
Gracefully handle rcode compiled with the `MIN-SIZE` option

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,5 @@
 *.i linguist-language=OpenEdge-ABL
 *.p linguist-language=OpenEdge-ABL
 *.w linguist-language=OpenEdge-ABL
+
+test_projects/proj1/import_charset.p text working-tree-encoding=UTF-8

--- a/resources/ablunit-test-profile.detail.jsonc
+++ b/resources/ablunit-test-profile.detail.jsonc
@@ -106,6 +106,8 @@
 		////#     the command line, and the "profiler.options" file will not be created.
 		////#   * When the "profiler" key is set to null the 'profile.options' file will not
 		////#     be created and the `-profile` option will not be passed to the command line.
+		////#   * When "enabled" is false, the profiler information is not collection and coverage cannot
+		////#     be reported.  This is not recommended.  The option is included here for completeness.
 		////#
 		////# See the OpenEdge documentation for more information about these values.
 		////#   * https://docs.progress.com/bundle/openedge-startup-and-parameter-reference/page/Profiler-profile.html

--- a/src/ABLDebugLines.ts
+++ b/src/ABLDebugLines.ts
@@ -31,7 +31,7 @@ export class ABLDebugLines {
 			try {
 				map = await getSourceMapFromRCode(this.propath, await this.propath.getRCodeUri(debugSource))
 			} catch (e) {
-				log.debug('cannot parse source map from rcode, falling back to source parser (debugSource=' + debugSource + ', e=' + e + ')')
+				log.warn('cannot parse source map from rcode, falling back to source parser (debugSource=' + debugSource + ', e=' + e + ')')
 				map = await getSourceMapFromSource(this.propath, debugSource)
 			}
 

--- a/src/ABLDebugLines.ts
+++ b/src/ABLDebugLines.ts
@@ -3,13 +3,18 @@ import { log } from './ChannelLogger'
 import { ISourceMap, getSourceMapFromRCode } from './parse/RCodeParser'
 import { getSourceMapFromSource } from './parse/SourceParser'
 
-const maps = new Map<string, ISourceMap>()
 
 export class ABLDebugLines {
+	private readonly maps = new Map<string, ISourceMap>()
+	private readonly processingMethodMap = new Map<string, 'rcode' | 'parse'>()
 	propath: PropathParser
 
 	constructor (propath: PropathParser) {
 		this.propath = propath
+	}
+
+	getProcessingMethod (debugSource: string) {
+		return this.processingMethodMap.get(debugSource)
 	}
 
 	async getSourceLine (debugSource: string, debugLine: number) {
@@ -26,19 +31,22 @@ export class ABLDebugLines {
 			log.trace('cannot find debug source in propath (' + debugSource + ')')
 			return undefined
 		}
-		let map = maps.get(debugSource)
+
+		let map = this.maps.get(debugSource)
 		if (!map) {
 			try {
 				map = await getSourceMapFromRCode(this.propath, await this.propath.getRCodeUri(debugSource))
+				this.processingMethodMap.set(debugSource, 'rcode')
 			} catch (e) {
 				log.warn('cannot parse source map from rcode, falling back to source parser (debugSource=' + debugSource + ', e=' + e + ')')
 				map = await getSourceMapFromSource(this.propath, debugSource)
+				this.processingMethodMap.set(debugSource, 'parse')
 			}
 
 			if (!map) {
 				throw new Error('failed to parse source map (' + debugSource + ')')
 			} else {
-				maps.set(debugSource, map)
+				this.maps.set(debugSource, map)
 			}
 		}
 		const ret = map.items.find((line) => line.debugLine === debugLine)

--- a/src/ABLPropath.ts
+++ b/src/ABLPropath.ts
@@ -147,7 +147,7 @@ export class PropathParser {
 		if (file instanceof Uri) {
 			return this.searchUri(file)
 		}
-		let relativeFile = file
+		let relativeFile = isRelativePath(file) ? file : workspace.asRelativePath(Uri.file(file), false)
 		if (!relativeFile.endsWith('.cls') && !relativeFile.endsWith('.p') && !relativeFile.endsWith('.w') && !relativeFile.endsWith('.i')) {
 			relativeFile = relativeFile.replace(/\./g, '/') + '.cls'
 		}

--- a/src/ABLUnitCommon.ts
+++ b/src/ABLUnitCommon.ts
@@ -36,7 +36,10 @@ export function doesFileExist (uri: Uri) {
 	return false
 }
 
-export function deleteFile (file: Uri | Uri[]) {
+export function deleteFile (file: Uri | Uri[] | undefined) {
+	if (!file) {
+		return
+	}
 	let files: Uri[]
 	if (!Array.isArray(file)) {
 		files = [file]
@@ -48,7 +51,7 @@ export function deleteFile (file: Uri | Uri[]) {
 			if (doesFileExist(file)) {
 				fs.rmSync(file.fsPath)
 			}
-		} catch (err) { /* do nothing */ }
+		} catch (e) { /* do nothing */ }
 	}
 }
 

--- a/src/ABLUnitCommon.ts
+++ b/src/ABLUnitCommon.ts
@@ -51,7 +51,8 @@ export function deleteFile (file: Uri | Uri[] | undefined) {
 			if (doesFileExist(file)) {
 				fs.rmSync(file.fsPath)
 			}
-		} catch (e) { /* do nothing */ }
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		} catch (err) { /* do nothing */ }
 	}
 }
 

--- a/src/ABLUnitRun.ts
+++ b/src/ABLUnitRun.ts
@@ -144,7 +144,6 @@ export const ablunitRun = async (options: TestRun, res: ABLResults, cancellation
 			cmd.push('-pf', res.cfg.ablunitConfig.dbConnPfUri.fsPath)
 		}
 
-		deleteFile(res.cfg.ablunitConfig.profFilenameUri)
 		if (res.cfg.ablunitConfig.profiler.enabled) {
 			cmd.push('-profile', res.cfg.ablunitConfig.profOptsUri.fsPath)
 		}
@@ -183,6 +182,14 @@ export const ablunitRun = async (options: TestRun, res: ABLResults, cancellation
 	}
 
 	const runCommand = () => {
+		deleteFile(res.cfg.ablunitConfig.profFilenameUri)
+		// deleteFile(res.cfg.ablunitConfig.config_uri)
+		deleteFile(res.cfg.ablunitConfig.optionsUri.filenameUri)
+		deleteFile(res.cfg.ablunitConfig.optionsUri.jsonUri)
+		deleteFile(res.cfg.ablunitConfig.optionsUri.updateUri)
+		deleteFile(res.cfg.ablunitConfig.profFilenameUri)
+		// deleteFile(res.cfg.ablunitConfig.profOptsUri)
+
 		log.debug('ablunit command dir=\'' + res.cfg.ablunitConfig.workspaceFolder.uri.fsPath + '\'')
 		if (cancellation?.isCancellationRequested) {
 			log.info('cancellation requested - runCommand')
@@ -199,7 +206,6 @@ export const ablunitRun = async (options: TestRun, res: ABLResults, cancellation
 
 			const updateUri = res.cfg.ablunitConfig.optionsUri.updateUri
 			if (updateUri) {
-				deleteFile(updateUri)
 				updateParserInit()
 				log.info('watching test run update/event file: ' + updateUri.fsPath)
 				watcherUpdate = workspace.createFileSystemWatcher(updateUri.fsPath)

--- a/src/ABLUnitRun.ts
+++ b/src/ABLUnitRun.ts
@@ -144,6 +144,7 @@ export const ablunitRun = async (options: TestRun, res: ABLResults, cancellation
 			cmd.push('-pf', res.cfg.ablunitConfig.dbConnPfUri.fsPath)
 		}
 
+		deleteFile(res.cfg.ablunitConfig.profFilenameUri)
 		if (res.cfg.ablunitConfig.profiler.enabled) {
 			cmd.push('-profile', res.cfg.ablunitConfig.profOptsUri.fsPath)
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,7 +109,6 @@ export async function activate (context: ExtensionContext) {
 		log.info('loadDetailedCoverage uri="' + fileCoverage.uri.fsPath + '", testRun=' + testRun.name)
 		const d = resultData.get(testRun)
 		const det: FileCoverageDetail[] = []
-
 		if (d) {
 			d.flatMap((r) => {
 				const rec = r.coverage.get(fileCoverage.uri.fsPath)
@@ -292,7 +291,7 @@ export async function activate (context: ExtensionContext) {
 				for (const res of data) {
 					log.info('res.filecoverage.length=' + res.filecoverage.length)
 					if (res.filecoverage.length === 0) {
-						log.warn('no coverage data found (profile data path=' + res.cfg.ablunitConfig.profFilenameUri + ')')
+						log.warn('no coverage data found (profile data path=' + res.cfg.ablunitConfig.profFilenameUri.fsPath + ')')
 					}
 					res.filecoverage.forEach((c) => {
 						run.addCoverage(c)

--- a/src/parse/RCodeParser.ts
+++ b/src/parse/RCodeParser.ts
@@ -2,6 +2,7 @@ import { TextDecoder } from 'util'
 import { Uri, workspace } from 'vscode'
 import { PropathParser } from '../ABLPropath'
 import { log } from '../ChannelLogger'
+import { isRelativePath } from 'ABLUnitCommon'
 
 const headerLength = 68
 
@@ -240,7 +241,7 @@ export const getSourceMapFromRCode = (propath: PropathParser, uri: Uri) => {
 		if (sourceNum == undefined) {
 			throw new Error('invalid source number: ' + sourceNum + ' ' + sourceName)
 		}
-		const sourceUri = Uri.joinPath(propath.workspaceFolder.uri, sourceName)
+		const sourceUri = isRelativePath(sourceName) ? Uri.joinPath(propath.workspaceFolder.uri, sourceName) : Uri.file(sourceName)
 
 		sources.push({
 			sourceName: sourceName.replace(/\\/g, '/'),

--- a/test/suites/proj1.test.ts
+++ b/test/suites/proj1.test.ts
@@ -1,6 +1,6 @@
 import { Selection, commands, tasks, window } from 'vscode'
 import { after, afterEach, beforeEach } from 'mocha'
-import { Uri, assert, getWorkspaceUri, log, runAllTests, sleep, updateConfig, getTestCount, workspace, suiteSetupCommon, getWorkspaceFolders, oeVersion, runTestAtLine, beforeCommon, updateTestProfile, runTestsInFile, sleep2, deleteFiles } from '../testCommon'
+import { Uri, assert, getWorkspaceUri, log, runAllTests, sleep, updateConfig, getTestCount, workspace, suiteSetupCommon, getWorkspaceFolders, oeVersion, runTestAtLine, beforeCommon, updateTestProfile, runTestsInFile, deleteFiles } from '../testCommon'
 import { getOEVersion } from 'parse/OpenedgeProjectParser'
 import { execSync } from 'child_process'
 import * as glob from 'glob'
@@ -151,16 +151,15 @@ suite('proj1 - Extension Test Suite', () => {
 			.then(() => {
 				log.info('testing.runAtCursor complete')
 				assert.tests.count(1)
-				assert.tests.passed(1)
-				assert.tests.failed(0)
+				assert.tests.passed(0)
+				assert.tests.failed(1)
 				assert.tests.errored(0)
-				return
 			})
 	})
 
 	test('proj1.9 - check startup parmaeters for -y -yx', async () => {
 		await workspace.fs.copy(Uri.joinPath(workspaceUri, 'openedge-project.proj1.9.json'), Uri.joinPath(workspaceUri, 'openedge-project.json'), { overwrite: true })
-		await runTestAtLine('import_charset.p', 64)
+		await runTestAtLine('import_charset.p', 68)
 			.then(() => {
 				log.info('testing.runAtCursor complete')
 				assert.tests.count(1)
@@ -276,22 +275,23 @@ suite('proj1 - Extension Test Suite', () => {
 	})
 
 	test('proj1.15A - compile option without MIN-SIZE without xref', () => {
-		return compileWithTaskAndCoverage('ant build')
+		const p = compileWithTaskAndCoverage('ant build')
 			.then(() => {
 				assert.linesExecuted('test_15.p', [9, 10, 13])
 				assert.coverageProcessingMethod('test_15.p', 'rcode')
 				return true
 			})
-
+		return p
 	})
 
 	test('proj1.15B - compile option with MIN-SIZE without xref', () => {
-		return compileWithTaskAndCoverage('ant build min-size')
+		const p = compileWithTaskAndCoverage('ant build min-size')
 			.then(() => {
 				assert.linesExecuted('test_15.p', [9, 10, 13])
 				assert.coverageProcessingMethod('test_15.p', 'parse')
 				return true
 			})
+		return p
 	})
 
 })
@@ -299,7 +299,7 @@ suite('proj1 - Extension Test Suite', () => {
 async function compileWithTaskAndCoverage (taskName: string) {
 	deleteFiles([
 		Uri.joinPath(workspaceUri, 'test_15.r'),
-		Uri.joinPath(workspaceUri, 'openedge-project.json')
+		Uri.joinPath(workspaceUri, 'openedge-project.json'),
 	])
 	await workspace.fs.copy(Uri.joinPath(workspaceUri, '.vscode', 'ablunit-test-profile.proj1.15.json'), Uri.joinPath(workspaceUri, '.vscode', 'ablunit-test-profile.json'), { overwrite: true })
 
@@ -316,7 +316,7 @@ async function compileWithTaskAndCoverage (taskName: string) {
 			}
 			return tasks.executeTask(task)
 		}).then((r) => {
-			log.info('executeTask started (r=' + JSON.stringify(r) + ')')
+			log.info('executeTask started (r=' + JSON.stringify(r, null, 2) + ')')
 		}, (e: unknown) => {
 			log.error('error=' + e)
 			throw e
@@ -324,7 +324,7 @@ async function compileWithTaskAndCoverage (taskName: string) {
 	await new Promise((resolve) => {
 		tasks.onDidEndTask((t) => {
 			log.info('task complete t.name=' + t.execution.task.name)
-			setTimeout(() => { resolve(true) }, 1000)
+			setTimeout(() => { resolve(true) }, 500)
 		})
 	})
 

--- a/test/testCommon.ts
+++ b/test/testCommon.ts
@@ -228,11 +228,26 @@ export function installExtension (extname = 'riversidesoftware.openedge-abl-lsp'
 		})
 }
 
-export function deleteFile (file: Uri | string) {
-	if (typeof file === 'string') {
-		file = Uri.joinPath(getWorkspaceUri(), file)
+export function deleteFile (files: Uri | Uri[] | string | string[]) {
+	const uris: Uri[] = []
+	if (!(files instanceof Array)) {
+		files = [files]
 	}
-	deleteFileCommon(file)
+	for (const file of files) {
+		if (file instanceof Uri) {
+			uris.push(file)
+		} else {
+			if (isRelativePath(file)) {
+				uris.push(Uri.joinPath(getWorkspaceUri(), file))
+			} else {
+				uris.push(Uri.file(file))
+			}
+		}
+	}
+
+	for (const uri of uris) {
+		deleteFileCommon(uri)
+	}
 }
 
 export function sleep2 (time = 10, msg?: string | null) {
@@ -578,12 +593,15 @@ export function runAllTestsWithCoverage () {
 	return runAllTests(true, true, true)
 }
 
-export function runTestsInFile (filename: string, len = 1) {
+export function runTestsInFile (filename: string, len = 1, coverage = false) {
 	const testpath = toUri(filename)
 	log.info('runnings tests in file ' + testpath.fsPath)
 	return commands.executeCommand('vscode.open', testpath)
 		.then(() => {
 			runTestsDuration = new Duration('runTestsInFile')
+			if (coverage) {
+				return commands.executeCommand('testing.coverageCurrentFile')
+			}
 			return commands.executeCommand('testing.runCurrentFile')
 		}, (e) => {
 			throw e
@@ -740,7 +758,7 @@ function getConfigDefaultValue (key: string) {
 	return undefined
 }
 
-export function updateConfig (key: string, value: unknown, configurationTarget?: boolean | vscode.ConfigurationTarget | null | undefined) {
+export function updateConfig (key: string, value: unknown, configurationTarget?: boolean | vscode.ConfigurationTarget | null) {
 	const sectionArr = key.split('.')
 	const section1 = sectionArr.shift()
 	const section2 = sectionArr.join('.')
@@ -904,7 +922,7 @@ function getType (item: TestItem | undefined) {
 	}
 }
 
-export function getTestControllerItemCount (type?: 'ABLTestDir' | 'ABLTestFile' | 'ABLTestCase' | undefined) {
+export function getTestControllerItemCount (type?: 'ABLTestDir' | 'ABLTestFile' | 'ABLTestCase') {
 	return getTestController()
 		.then((ctrl) => {
 			const items = gatherAllTestItems(ctrl.items)
@@ -1106,7 +1124,7 @@ export const assert = {
 	notStrictEqual: assertParent.notStrictEqual,
 	deepEqual: assertParent.deepEqual,
 	notDeepEqual: assertParent.notDeepEqual,
-	fail: assertParent.fail,
+	fail: (message: string) => { assertParent.fail(message) },
 	ok: (value: unknown) => {
 		assertParent.ok(value)
 	},
@@ -1132,6 +1150,7 @@ export const assert = {
 				return
 			})
 		} catch (e) {
+			log.info('exception thrown as expected: ' + e + '. message=' + message)
 			assertParent.ok(true)
 		}
 	},
@@ -1186,7 +1205,21 @@ export const assert = {
 	},
 	tests: new AssertTestResults(),
 
-	linesExecuted (file: Uri | string, lines: number[] | number, notExecuted = false) {
+	coveredFiles (expected: number) {
+		if (!recentResults) {
+			assert.fail('recentResults is undefined')
+			return
+		}
+		if (recentResults.length == 0) {
+			assert.fail('recentResults.length is 0')
+			return
+		}
+
+		const actual = recentResults[recentResults.length - 1].coverage.size
+		assert.equal(actual, expected, 'covered files (' + actual + ') != ' + expected)
+	},
+
+	linesExecuted (file: Uri | string, lines: number[] | number, executed = true) {
 		if (!(file instanceof Uri)) {
 			file = toUri(file)
 		}
@@ -1202,7 +1235,7 @@ export const assert = {
 			return
 		}
 
-		const coverage = recentResults[0].coverage.get(file.fsPath)
+		const coverage = recentResults[recentResults.length - 1].coverage.get(file.fsPath)
 		if (!coverage) {
 			assert.fail('no coverage found for ' + file.fsPath)
 			return
@@ -1217,15 +1250,16 @@ export const assert = {
 				assert.fail('expected number for coverage executed but got boolean (' + lineCoverage.executed + ')')
 				return
 			}
-			if (notExecuted) {
+			if (!executed) {
 				assert.equal(lineCoverage?.executed, 0, 'line ' + line + ' in ' + file.fsPath + ' was executed')
 			} else {
 				assert.greater(lineCoverage?.executed, 0, 'line ' + line + ' in ' + file.fsPath + ' was not executed')
 			}
 		}
 	},
+
 	linesNotExecuted (file: Uri | string, lines: number[] | number) {
-		assert.linesExecuted(file, lines, true)
+		assert.linesExecuted(file, lines, false)
 	}
 }
 
@@ -1249,7 +1283,7 @@ export function beforeProj7 () {
 			return Promise.all(proms)
 		}).then(() => {
 			log.info('beforeProj7 complete!')
-			return
+			return true
 		})
 }
 

--- a/test_projects/proj1/.vscode/ablunit-test-profile.proj1.15.json
+++ b/test_projects/proj1/.vscode/ablunit-test-profile.proj1.15.json
@@ -1,0 +1,12 @@
+{
+	"configurations": [
+		{
+			"tempDir": "${workspaceFolder}",
+			"options": {
+				"output": {
+					"writeJson": true
+				}
+			}
+		}
+	]
+}

--- a/test_projects/proj1/.vscode/tasks.json
+++ b/test_projects/proj1/.vscode/tasks.json
@@ -4,6 +4,9 @@
             "label": "ant build",
             "type": "shell",
             "command": "${env:DLC}/ant/bin/ant compile -Dxref=false",
+            "linux": {
+                "command": "ant compile -Dxref=false"
+            },
             "args": [],
             "group": {
                 "kind": "build",
@@ -15,6 +18,9 @@
             "label": "ant build min-size",
             "type": "shell",
             "command": "${env:DLC}/ant/bin/ant compile -DminSize=true -Dxref=false",
+            "linux": {
+                "command": "ant compile -DminSize=true -Dxref=false"
+            },
             "args": [],
             "group": {
                 "kind": "build",

--- a/test_projects/proj1/.vscode/tasks.json
+++ b/test_projects/proj1/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+    "tasks": [
+        {
+            "label": "ant build",
+            "type": "shell",
+            "command": "${env:DLC}/ant/bin/ant compile -Dxref=false",
+            "args": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "ant build min-size",
+            "type": "shell",
+            "command": "${env:DLC}/ant/bin/ant compile -DminSize=true -Dxref=false",
+            "args": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/test_projects/proj1/build.xml
+++ b/test_projects/proj1/build.xml
@@ -26,9 +26,12 @@
   </target>
 
   <target name="compile">
+    <property name="minSize" value="false" />
+    <property name="xref" value="true" />
     <echo>Compiling...</echo>
+    <echo>minSize=${minSize}</echo>
 
-    <PCTCompile forceCompile="true" xrefDir=".xref" keepXref="true" xmlXref="true">
+    <PCTCompile forceCompile="true" xrefDir=".xref" keepXref="${xref}" xmlXref="${xref}" minSize="${minSize}">
       <fileset dir="." includes="*.p,*.cls" excludes="compileError.p,propathTest.p" />
     </PCTCompile>
   </target>

--- a/test_projects/proj1/import_charset.p
+++ b/test_projects/proj1/import_charset.p
@@ -15,14 +15,18 @@ procedure euro_symbol_out_and_in :
     define variable testVar as character no-undo.
     define variable impVal as character no-undo.
 
-    message "session:cpinternal=" + session:cpinternal.
-    message "session:cpstream=" + session:cpstream.
+    message "1 session:cpinternal=" + session:cpinternal.
+    message "1 session:cpstream=" + session:cpstream.
 
     testVar = "euro symbol: €".
 
     output stream oStream to "./import_charset.out".
     put stream oStream unformatted testVar.
     output stream oStream close.
+
+    // session:cpstream = session:cpinternal.
+    message "2 session:cpinternal=" + session:cpinternal.
+    message "2 session:cpstream=" + session:cpstream.
 
     input stream iStream from "./import_charset.out".
     import stream iStream unformatted impVal.

--- a/test_projects/proj1/include_15.i
+++ b/test_projects/proj1/include_15.i
@@ -1,0 +1,3 @@
+message "in include_15.i".
+define variable cnt as integer no-undo.
+cnt = 1.

--- a/test_projects/proj1/test_15.p
+++ b/test_projects/proj1/test_15.p
@@ -1,0 +1,16 @@
+block-level on error undo, throw.
+using OpenEdge.Core.Assert.
+
+message 'test_15.p starting'.
+
+{include_15.i}
+
+@Test.
+procedure test_A :
+    if true then
+        message "in test_A".
+    else
+        message "this does not execute".
+    Assert:isTrue(true).
+end procedure.
+


### PR DESCRIPTION
In this case the rcode won't have debug info and processing will revert to a less accurate method that attempts to determine line numbers by parsing code.