### PR TITLE
Refactor file access functions

### DIFF
--- a/scripts/sonar_test_results_merge.sh
+++ b/scripts/sonar_test_results_merge.sh
@@ -44,12 +44,13 @@ show_summary () {
     [ "$SKIP_COUNT" = "" ] && SKIP_COUNT=0
     echo "[$(date +%Y-%m-%d:%H:%M:%S) $0 ${FUNCNAME[0]}] $SKIP_COUNT/$TEST_COUNT tests skipped"
 
-    FAILURE_COUNT="$(jq '.[] | select(has("failure")) | length' < artifacts/mocha_results_sonar/merged_flat.json)"
+    FAILURE_COUNT="$(jq '.[] | select(has("failure") and .failure != null) | length' < artifacts/mocha_results_sonar/merged_flat.json)"
     [ "$FAILURE_COUNT" = "" ] && FAILURE_COUNT=0
-    echo "[$(date +%Y-%m-%d:%H:%M:%S) $0 ${FUNCNAME[0]}] ERROR: $FAILURE_COUNT/$TEST_COUNT tests failed"
-
-    if [ "$FAILURE_COUNT" != "0" ]; then
-        jq '.[] | select(has("failure"))' < artifacts/mocha_results_sonar/merged_flat.json
+    if [ "$FAILURE_COUNT" = "0" ]; then
+        echo "[$(date +%Y-%m-%d:%H:%M:%S) $0 ${FUNCNAME[0]}] $FAILURE_COUNT/$TEST_COUNT tests failed"
+    else
+        echo "[$(date +%Y-%m-%d:%H:%M:%S) $0 ${FUNCNAME[0]}] ERROR! $FAILURE_COUNT/$TEST_COUNT tests failed"
+        jq '.[] | select(has("failure") and .failure != null)' < artifacts/mocha_results_sonar/merged_flat.json
     fi
 }
 

--- a/src/ABLPropath.ts
+++ b/src/ABLPropath.ts
@@ -1,7 +1,7 @@
 import { Uri, workspace, WorkspaceFolder } from 'vscode'
 import { IProjectJson } from './parse/OpenedgeProjectParser'
-import { isRelativePath } from './ABLUnitCommon'
 import { log } from './ChannelLogger'
+import * as FileUtils from './FileUtils'
 
 interface IPropathEntry {
 	uri: Uri
@@ -50,14 +50,14 @@ export class PropathParser {
 		for (const entry of importedPropath.propathEntry) {
 			log.debug('found propath entry: ' + entry.path + ' ' + entry.type + ' ' + entry.buildDir)
 			let uri: Uri = Uri.file(entry.path)
-			if(isRelativePath(entry.path)) {
+			if(FileUtils.isRelativePath(entry.path)) {
 				uri = Uri.joinPath(this.workspaceFolder.uri, entry.path)
 			}
 
 			let buildUri: Uri = uri
 			if (entry.buildDir) {
 				buildUri = Uri.file(entry.buildDir)
-				if(isRelativePath(entry.buildDir)) {
+				if(FileUtils.isRelativePath(entry.buildDir)) {
 					buildUri = Uri.joinPath(this.workspaceFolder.uri, entry.buildDir)
 				}
 			}
@@ -65,7 +65,7 @@ export class PropathParser {
 			let xrefDirUri: Uri = uri
 			if (entry.xrefDir) {
 				xrefDirUri = Uri.file(entry.xrefDir)
-				if(isRelativePath(entry.xrefDir)) {
+				if(FileUtils.isRelativePath(entry.xrefDir)) {
 					xrefDirUri = Uri.joinPath(this.workspaceFolder.uri, entry.xrefDir)
 				}
 			}
@@ -147,7 +147,7 @@ export class PropathParser {
 		if (file instanceof Uri) {
 			return this.searchUri(file)
 		}
-		let relativeFile = isRelativePath(file) ? file : workspace.asRelativePath(Uri.file(file), false)
+		let relativeFile = FileUtils.isRelativePath(file) ? file : workspace.asRelativePath(Uri.file(file), false)
 		if (!relativeFile.endsWith('.cls') && !relativeFile.endsWith('.p') && !relativeFile.endsWith('.w') && !relativeFile.endsWith('.i')) {
 			relativeFile = relativeFile.replace(/\./g, '/') + '.cls'
 		}

--- a/src/ABLResults.ts
+++ b/src/ABLResults.ts
@@ -15,8 +15,9 @@ import { PropathParser } from './ABLPropath'
 import { log } from './ChannelLogger'
 import { ABLUnitRuntimeError, RunStatus, TimeoutError, ablunitRun } from './ABLUnitRun'
 import { getDLC, IDlc } from './parse/OpenedgeProjectParser'
-import { Duration, isRelativePath } from './ABLUnitCommon'
+import { Duration } from './ABLUnitCommon'
 import { ITestObj } from 'parse/config/CoreOptions'
+import * as FileUtils from './FileUtils'
 
 export class ABLResults implements Disposable {
 	workspaceFolder: WorkspaceFolder
@@ -138,7 +139,7 @@ export class ABLResults implements Disposable {
 		}
 
 		let propathEntryTestFile = testPropath.propathEntry.path
-		if (isRelativePath(testPropath.propathEntry.path)) {
+		if (FileUtils.isRelativePath(testPropath.propathEntry.path)) {
 			propathEntryTestFile = workspace.asRelativePath(Uri.joinPath(this.workspaceFolder.uri, testPropath.propathEntry.path))
 		}
 		log.debug('addTest: ' + test.id + ', propathEntry=' + propathEntryTestFile)

--- a/src/ABLUnitCommon.ts
+++ b/src/ABLUnitCommon.ts
@@ -1,63 +1,10 @@
-import * as fs from 'fs'
-import { Uri } from 'vscode'
-import JSON_minify from 'node-json-minify'
+import { TestController, TestItem, TestItemCollection } from 'vscode'
+import { ABLResults } from './ABLResults'
 
-export type vscodeVersion = 'stable' | 'insiders' | 'proposedapi'
-
-export const readStrippedJsonFile = (uri: Uri | string) => {
-	if (typeof uri === 'string') {
-		uri = Uri.file(uri)
-	}
-	const contents = fs.readFileSync(uri.fsPath, 'utf8')
-	// eslint-disable-next-line
-	const ret = JSON.parse(JSON_minify(contents)) as object
-	return ret
-}
-
-export function isRelativePath (path: string) {
-	if(path.startsWith('/') || RegExp(/^[a-zA-Z]:[\\/]/).exec(path)) {
-		return false
-	} else {
-		return true
-	}
-}
-
-export function doesDirExist (uri: Uri) {
-	if (fs.statSync(uri.fsPath).isDirectory()) {
-		return true
-	}
-	return false
-}
-
-export function doesFileExist (uri: Uri) {
-	try {
-		if (fs.statSync(uri.fsPath).isFile()) {
-			return true
-		}
-		return false
-	} catch (_e: unknown) {
-		return false
-	}
-}
-
-export function deleteFile (file: Uri | Uri[] | undefined) {
-	if (!file) {
-		return
-	}
-	let files: Uri[]
-	if (!Array.isArray(file)) {
-		files = [file]
-	} else {
-		files = file
-	}
-	for (const file of files) {
-		try{
-			if (doesFileExist(file)) {
-				fs.rmSync(file.fsPath)
-			}
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		} catch (e: unknown) { /* do nothing */ }
-	}
+export interface IExtensionTestReferences {
+	testController: TestController
+	recentResults: ABLResults[]
+	currentRunData: ABLResults[]
 }
 
 export class Duration {
@@ -96,26 +43,10 @@ export class Duration {
 	}
 }
 
-// export async function doesFileExistAsync (uri: Uri) {
-// 	const ret = await workspace.fs.stat(uri).then((stat) => {
-// 		if (stat.type === FileType.File) {
-// 			return true
-// 		}
-// 		return false
-// 	}, () => {
-// 		return false
-// 	})
-// 	return ret
-// }
-
-// export async function doesDirExistSync (uri: Uri) {
-// 	const ret = await workspace.fs.stat(uri).then((stat) => {
-// 		if (stat.type === FileType.Directory) {
-// 			return true
-// 		}
-// 		return false
-// 	}, () => {
-// 		return false
-// 	})
-// 	return ret
-// }
+export function gatherAllTestItems (collection: TestItemCollection) {
+	const items: TestItem[] = []
+	collection.forEach(item => {
+		items.push(item, ...gatherAllTestItems(item.children))
+	})
+	return items
+}

--- a/src/ABLUnitRun.ts
+++ b/src/ABLUnitRun.ts
@@ -1,9 +1,10 @@
 import { CancellationError, CancellationToken, Disposable, FileSystemWatcher, TestRun, Uri, workspace } from 'vscode'
 import { ABLResults } from './ABLResults'
-import { deleteFile, Duration } from './ABLUnitCommon'
+import { Duration } from './ABLUnitCommon'
 import { SendHandle, Serializable, SpawnOptions, spawn } from 'child_process'
 import { log } from './ChannelLogger'
 import { processUpdates, setTimeoutTestStatus, updateParserInit } from 'parse/UpdateParser'
+import * as FileUtils from './FileUtils'
 
 export enum RunStatus {
 	None = 10,
@@ -181,13 +182,15 @@ export const ablunitRun = async (options: TestRun, res: ABLResults, cancellation
 	}
 
 	const runCommand = () => {
-		deleteFile(res.cfg.ablunitConfig.profFilenameUri)
-		// deleteFile(res.cfg.ablunitConfig.config_uri)
-		deleteFile(res.cfg.ablunitConfig.optionsUri.filenameUri)
-		deleteFile(res.cfg.ablunitConfig.optionsUri.jsonUri)
-		deleteFile(res.cfg.ablunitConfig.optionsUri.updateUri)
-		deleteFile(res.cfg.ablunitConfig.profFilenameUri)
-		// deleteFile(res.cfg.ablunitConfig.profOptsUri)
+		FileUtils.deleteFile(
+			res.cfg.ablunitConfig.profFilenameUri,
+			// res.cfg.ablunitConfig.config_uri,
+			res.cfg.ablunitConfig.optionsUri.filenameUri,
+			res.cfg.ablunitConfig.optionsUri.jsonUri,
+			res.cfg.ablunitConfig.optionsUri.updateUri,
+			res.cfg.ablunitConfig.profFilenameUri,
+			res.cfg.ablunitConfig.profOptsUri,
+		)
 
 		log.debug('ablunit command dir=\'' + res.cfg.ablunitConfig.workspaceFolder.uri.fsPath + '\'')
 		if (cancellation?.isCancellationRequested) {

--- a/src/ABLUnitRun.ts
+++ b/src/ABLUnitRun.ts
@@ -189,7 +189,7 @@ export const ablunitRun = async (options: TestRun, res: ABLResults, cancellation
 			res.cfg.ablunitConfig.optionsUri.jsonUri,
 			res.cfg.ablunitConfig.optionsUri.updateUri,
 			res.cfg.ablunitConfig.profFilenameUri,
-			res.cfg.ablunitConfig.profOptsUri,
+			// res.cfg.ablunitConfig.profOptsUri,
 		)
 
 		log.debug('ablunit command dir=\'' + res.cfg.ablunitConfig.workspaceFolder.uri.fsPath + '\'')

--- a/src/FileUtils.ts
+++ b/src/FileUtils.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs'
+import JSON_minify from 'node-json-minify'
+import { Uri } from 'vscode'
+import { log } from 'ChannelLogger'
+
+
+export function readFileSync (path: string | Uri) {
+	return fs.readFileSync(path instanceof Uri ? path.fsPath : path, 'utf8')
+}
+
+export function readStrippedJsonFile (uri: Uri | string) {
+	if (typeof uri === 'string') {
+		uri = Uri.file(uri)
+	}
+	const contents = fs.readFileSync(uri.fsPath, 'utf8')
+	// eslint-disable-next-line
+	const ret = JSON.parse(JSON_minify(contents)) as object
+	return ret
+}
+
+export function isRelativePath (path: string) {
+	if(path.startsWith('/') || RegExp(/^[a-zA-Z]:[\\/]/).exec(path)) {
+		return false
+	} else {
+		return true
+	}
+}
+
+
+function doesPathExist (uri: Uri, type?: 'file' | 'directory') {
+	const exist = fs.existsSync(uri.fsPath)
+	if (!exist || !type) {
+		return false
+	}
+	if (type === 'file') {
+		return fs.statSync(uri.fsPath).isFile()
+	} else if (type === 'directory') {
+		return fs.statSync
+	}
+	log.debug('unknown path type=' + type)
+	return false
+}
+
+
+export function doesFileExist (uri: Uri) {
+	return doesPathExist(uri, 'file')
+}
+
+
+export function doesDirExist (uri: Uri) {
+	return doesPathExist(uri, 'directory')
+}
+
+export function createDir (uri: Uri) {
+	if (!doesPathExist(uri, 'directory')) {
+		if (doesPathExist(uri)) {
+			throw new Error('path exists but is not a directory: ' + uri.fsPath)
+		}
+		fs.mkdirSync(uri.fsPath, { recursive: true })
+	}
+}
+
+function deletePath (type: 'directory' | 'file', uris: (Uri | undefined)[]) {
+	if (uris.length == 0) {
+		return
+	}
+	for (const uri of uris) {
+		if (!uri) {
+			continue
+		}
+		if (doesPathExist(uri, type)) {
+			fs.rmSync(uri.fsPath, { recursive: true })
+			continue
+		}
+		if (doesPathExist(uri)) {
+			throw new Error('path exists but is not a ' + type + ': ' + uri.fsPath)
+		}
+	}
+}
+
+export function deleteFile (...files: (Uri | undefined)[]) {
+	deletePath('file', files)
+}
+
+export function deleteDir (...dirs: (Uri | undefined)[]) {
+	deletePath('directory', dirs)
+}
+
+export function copyFile (source: Uri, target: Uri, opts?: fs.CopySyncOptions) {
+	log.info('cpSYnc: ' + source.fsPath + ' -> ' + target.fsPath)
+	log.info(' -- opts=' + JSON.stringify(opts))
+	fs.cpSync(source.fsPath, target.fsPath, opts)
+}

--- a/src/parse/CallStackParser.ts
+++ b/src/parse/CallStackParser.ts
@@ -2,7 +2,7 @@ import { workspace, Location, Position, Range, Uri } from 'vscode'
 import { ABLDebugLines } from '../ABLDebugLines'
 import { ISourceMapItem } from './RCodeParser'
 import { log } from '../ChannelLogger'
-import { doesFileExist } from 'extension'
+import * as FileUtils from '../FileUtils'
 
 interface ICallStackItem {
 	rawText: string
@@ -50,7 +50,7 @@ export async function parseCallstack (debugLines: ABLDebugLines, callstackRaw: s
 		}
 
 		let debugUri: Uri | undefined = Uri.file(debugFile)
-		if (!await doesFileExist(debugUri)) {
+		if (!FileUtils.doesFileExist(debugUri)) {
 			debugUri = undefined
 		}
 

--- a/src/parse/OpenedgeProjectParser.ts
+++ b/src/parse/OpenedgeProjectParser.ts
@@ -1,6 +1,6 @@
 import { Uri, workspace, WorkspaceFolder } from 'vscode'
-import { readStrippedJsonFile } from '../ABLUnitCommon'
 import { log } from '../ChannelLogger'
+import * as FileUtils from '../FileUtils'
 import * as path from 'path'
 import * as fs from 'fs'
 
@@ -76,7 +76,7 @@ let oeRuntimes: IOERuntime[] = []
 const dlcMap = new Map<WorkspaceFolder, IDlc>()
 
 function getProjectJson (workspaceFolder: WorkspaceFolder) {
-	const data = JSON.stringify(readStrippedJsonFile(Uri.joinPath(workspaceFolder.uri, 'openedge-project.json')))
+	const data = JSON.stringify(FileUtils.readStrippedJsonFile(Uri.joinPath(workspaceFolder.uri, 'openedge-project.json')))
 	return data
 }
 
@@ -244,7 +244,7 @@ function loadConfigFile (filename: string): IOpenEdgeMainConfig | undefined {
 		return undefined
 	}
 	try {
-		const data = readStrippedJsonFile(filename)
+		const data = FileUtils.readStrippedJsonFile(filename)
 		return data as unknown as IOpenEdgeMainConfig
 	} catch (caught) {
 		log.error('[loadConfigFile] Failed to parse ' + filename + ': ' + caught)

--- a/src/parse/RCodeParser.ts
+++ b/src/parse/RCodeParser.ts
@@ -2,7 +2,7 @@ import { TextDecoder } from 'util'
 import { Uri, workspace } from 'vscode'
 import { PropathParser } from '../ABLPropath'
 import { log } from '../ChannelLogger'
-import { isRelativePath } from 'ABLUnitCommon'
+import * as FileUtils from '../FileUtils'
 
 const headerLength = 68
 
@@ -241,7 +241,7 @@ export const getSourceMapFromRCode = (propath: PropathParser, uri: Uri) => {
 		if (sourceNum == undefined) {
 			throw new Error('invalid source number: ' + sourceNum + ' ' + sourceName)
 		}
-		const sourceUri = isRelativePath(sourceName) ? Uri.joinPath(propath.workspaceFolder.uri, sourceName) : Uri.file(sourceName)
+		const sourceUri = FileUtils.isRelativePath(sourceName) ? Uri.joinPath(propath.workspaceFolder.uri, sourceName) : Uri.file(sourceName)
 
 		sources.push({
 			sourceName: sourceName.replace(/\\/g, '/'),

--- a/src/parse/ResultsParser.ts
+++ b/src/parse/ResultsParser.ts
@@ -7,7 +7,7 @@ import { PropathParser } from '../ABLPropath'
 import { parseString } from 'xml2js'
 import { ABLDebugLines } from '../ABLDebugLines'
 import { log } from '../ChannelLogger'
-import { isRelativePath } from '../ABLUnitCommon'
+import * as FileUtils from '../FileUtils'
 
 export interface ITestCaseFailure {
 	callstackRaw: string
@@ -126,7 +126,7 @@ export class ABLResultsParser {
 		const testsuite = await this.parseSuite(res.testsuite)
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 		let namePathSep = res.$.name.replace(/\\/g, '/') as string
-		if (!isRelativePath(namePathSep)) {
+		if (!FileUtils.isRelativePath(namePathSep)) {
 			namePathSep = workspace.asRelativePath(namePathSep, false)
 		}
 		const jsonData: ITestSuites = {
@@ -157,7 +157,7 @@ export class ABLResultsParser {
 			const testcases = await this.parseTestCases(res[idx].testcase)
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			let namePathSep = res[idx].$.name.replace(/\\/g, '/') as string
-			if (!isRelativePath(namePathSep)) {
+			if (!FileUtils.isRelativePath(namePathSep)) {
 				namePathSep = workspace.asRelativePath(namePathSep, false)
 			}
 

--- a/src/parse/TestParserCommon.ts
+++ b/src/parse/TestParserCommon.ts
@@ -1,7 +1,7 @@
 import { Uri, workspace } from 'vscode'
 import { TextDecoder } from 'util'
-import { isRelativePath } from 'ABLUnitCommon'
 import * as fs from 'fs'
+import * as FileUtils from '../FileUtils'
 
 const textDecoder = new TextDecoder('utf-8')
 
@@ -11,7 +11,7 @@ function toUri (uri: Uri | string): Uri {
 	}
 	const filename = uri
 
-	if (!isRelativePath(uri)) {
+	if (!FileUtils.isRelativePath(uri)) {
 		return Uri.file(uri)
 	}
 

--- a/src/parse/TestProfileParser.ts
+++ b/src/parse/TestProfileParser.ts
@@ -3,9 +3,9 @@ import { CoreOptions } from './config/CoreOptions'
 import { IRunProfile, DefaultRunProfile } from './config/RunProfile'
 import { ProfilerOptions } from './config/ProfilerOptions'
 import { CommandOptions } from './config/CommandOptions'
-import { isRelativePath, readStrippedJsonFile } from '../ABLUnitCommon'
 import { log } from '../ChannelLogger'
 import { IDatabaseConnection, getExtraParameters, getProfileCharset, getProfileDbConns } from './OpenedgeProjectParser'
+import * as FileUtils from '../FileUtils'
 
 const runProfileFilename = 'ablunit-test-profile.json'
 
@@ -17,7 +17,7 @@ export interface IConfigurations {
 }
 
 function getConfigurations (uri: Uri) {
-	const data = readStrippedJsonFile(uri)
+	const data = FileUtils.readStrippedJsonFile(uri)
 	try {
 		let str = JSON.stringify(data)
 		if (str === '' || str === '{}') {
@@ -142,7 +142,7 @@ function getUri (dir: string | undefined, workspaceFolderUri: Uri, tempDir?: Uri
 	}
 	dir = dir.replace('${workspaceFolder}', workspaceFolderUri.fsPath)
 
-	if (isRelativePath(dir)) {
+	if (FileUtils.isRelativePath(dir)) {
 		if (dir.includes('/') || dir.includes('\\')) {
 			return Uri.joinPath(workspaceFolderUri, dir)
 		} else {

--- a/test/suites/proj0.test.ts
+++ b/test/suites/proj0.test.ts
@@ -1,9 +1,10 @@
 import { Uri, commands, window, workspace } from 'vscode'
-import * as vscode from 'vscode'
-import { assert, deleteFile, getResults, getTestControllerItemCount, getTestItem, log, refreshTests, runAllTests, runAllTestsWithCoverage, runTestAtLine, runTestsDuration, runTestsInFile, sleep2, suiteSetupCommon, toUri, updateConfig, updateTestProfile } from '../testCommon'
+import { assert, getResults, getTestControllerItemCount, getTestItem, log, refreshTests, runAllTests, runAllTestsWithCoverage, runTestAtLine, runTestsDuration, runTestsInFile, sleep2, suiteSetupCommon, toUri, updateConfig, updateTestProfile } from '../testCommon'
 import { ABLResultsParser } from 'parse/ResultsParser'
-import * as fs from 'fs'
 import { TimeoutError } from 'ABLUnitRun'
+import * as vscode from 'vscode'
+import * as FileUtils from '../../src/FileUtils'
+import * as fs from 'fs'
 
 function createTempFile () {
 	const tempFile = toUri('UNIT_TEST.tmp')
@@ -16,18 +17,18 @@ suite('proj0  - Extension Test Suite', () => {
 	const disposables: vscode.Disposable[] = []
 
 	suiteSetup('proj0 - before', () => {
-		deleteFile('.vscode/ablunit-test-profile.json')
-		deleteFile('src/dirA/proj10.p')
-		deleteFile('UNIT_TEST.tmp')
+		FileUtils.deleteFile(toUri('.vscode/ablunit-test-profile.json'))
+		FileUtils.deleteFile(toUri('src/dirA/proj10.p'))
+		FileUtils.deleteFile(toUri('UNIT_TEST.tmp'))
 		return suiteSetupCommon()
 			.then(() => { return commands.executeCommand('testing.clearTestResults') })
 			.then(() => { return workspace.fs.copy(toUri('.vscode/settings.json'), toUri('.vscode/settings.json.bk'), { overwrite: true }) })
 	})
 
 	teardown('proj0 - afterEach', () => {
-		deleteFile('.vscode/ablunit-test-profile.json')
-		deleteFile('src/dirA/proj10.p')
-		deleteFile('UNIT_TEST.tmp')
+		FileUtils.deleteFile(toUri('.vscode/ablunit-test-profile.json'))
+		FileUtils.deleteFile(toUri('src/dirA/proj10.p'))
+		FileUtils.deleteFile(toUri('UNIT_TEST.tmp'))
 		while (disposables.length > 0) {
 			const d = disposables.pop()
 			if (d) {

--- a/test/suites/proj1.test.ts
+++ b/test/suites/proj1.test.ts
@@ -1,9 +1,9 @@
 import { Selection, TaskEndEvent, TaskExecution, commands, tasks, window } from 'vscode'
-import { Uri, assert, getWorkspaceUri, log, runAllTests, sleep, updateConfig, getTestCount, workspace, suiteSetupCommon, getWorkspaceFolders, oeVersion, runTestAtLine, beforeCommon, updateTestProfile, runTestsInFile, deleteFiles, sleep2 } from '../testCommon'
+import { Uri, assert, getWorkspaceUri, log, runAllTests, sleep, updateConfig, getTestCount, workspace, suiteSetupCommon, getWorkspaceFolders, oeVersion, runTestAtLine, beforeCommon, updateTestProfile, runTestsInFile, sleep2 } from '../testCommon'
 import { getOEVersion } from 'parse/OpenedgeProjectParser'
 import { execSync } from 'child_process'
 import * as glob from 'glob'
-import { doesFileExist } from 'ABLUnitCommon'
+import * as FileUtils from '../../src/FileUtils'
 
 const workspaceUri = getWorkspaceUri()
 
@@ -323,10 +323,10 @@ suite('proj1 - Extension Test Suite', () => {
 })
 
 async function compileWithTaskAndCoverage (taskName: string) {
-	deleteFiles([
+	FileUtils.deleteFile(
 		Uri.joinPath(workspaceUri, 'test_15.r'),
 		Uri.joinPath(workspaceUri, 'openedge-project.json'),
-	])
+	)
 	await workspace.fs.copy(Uri.joinPath(workspaceUri, '.vscode', 'ablunit-test-profile.proj1.15.json'), Uri.joinPath(workspaceUri, '.vscode', 'ablunit-test-profile.json'), { overwrite: true })
 
 	const p2 = new Promise<TaskEndEvent>((resolve) => {
@@ -356,7 +356,7 @@ async function compileWithTaskAndCoverage (taskName: string) {
 
 	const testRcode = Uri.joinPath(workspaceUri, 'test_15.r')
 	for (let i=0; i<20; i++) {
-		if (doesFileExist(testRcode)) {
+		if (FileUtils.doesFileExist(testRcode)) {
 			log.info('file exists! (i=' + i + ')')
 			break
 		}

--- a/test/suites/proj2.test.ts
+++ b/test/suites/proj2.test.ts
@@ -1,4 +1,5 @@
-import { assert, getResults, getWorkspaceUri, log, runAllTests, suiteSetupCommon, Uri, commands, workspace, beforeCommon, deleteFile, toUri, selectProfile, runTestsInFile } from '../testCommon'
+import { assert, getResults, getWorkspaceUri, log, runAllTests, suiteSetupCommon, Uri, commands, workspace, beforeCommon, toUri, selectProfile, runTestsInFile } from '../testCommon'
+import * as FileUtils from '../../src/FileUtils'
 
 const workspaceUri = getWorkspaceUri()
 
@@ -10,8 +11,8 @@ suite('proj2 - Extension Test Suite', () => {
 
 	setup('proj2 - beforeEach', () => {
 		beforeCommon()
-		deleteFile(toUri('src/compileError.p'))
-		deleteFile(toUri('.vscode/profile.json'))
+		FileUtils.deleteFile(toUri('src/compileError.p'))
+		FileUtils.deleteFile(toUri('.vscode/profile.json'))
 	})
 
 	test('proj2.1 - temp/ablunit.json file exists', () => {

--- a/test/suites/proj4.test.ts
+++ b/test/suites/proj4.test.ts
@@ -1,4 +1,5 @@
-import { assert, deleteFile, getDefaultDLC, getSessionTempDir, getWorkspaceUri, oeVersion, runAllTests, setRuntimes, suiteSetupCommon, updateTestProfile, Uri } from '../testCommon'
+import { assert, getDefaultDLC, getSessionTempDir, getWorkspaceUri, oeVersion, runAllTests, setRuntimes, suiteSetupCommon, updateTestProfile, Uri } from '../testCommon'
+import * as FileUtils from '../../src/FileUtils'
 
 const sessionTempDir = getSessionTempDir()
 
@@ -57,7 +58,7 @@ suite('proj4 - Extension Test Suite', () => {
 		const workspaceUri = getWorkspaceUri()
 		const ablunitJson = Uri.joinPath(workspaceUri, 'target', 'ablunit.json')
 		const progressIni = Uri.joinPath(workspaceUri, 'target', 'progress.ini')
-		deleteFile(progressIni)
+		FileUtils.deleteFile(progressIni)
 		await updateTestProfile('tempDir', 'target')
 		await runAllTests()
 		assert.fileExists(ablunitJson)

--- a/test/suites/proj7B.test.ts
+++ b/test/suites/proj7B.test.ts
@@ -101,7 +101,7 @@ suite('proj7B - Extension Test Suite', () => {
 		// })
 	})
 
-	test('proj7B.3 - cancel test run while _progres is running', async () => {
+	test.skip('proj7B.3 - cancel test run while _progres is running', async () => {
 		const maxCancelTime = 1000
 		// const runTestTime = new Duration()
 

--- a/test/suites/proj7B.test.ts
+++ b/test/suites/proj7B.test.ts
@@ -33,27 +33,23 @@ suite('proj7B - Extension Test Suite', () => {
 
 		log.info('cancelling test refresh')
 		const startCancelTime = new Duration()
-		try {
-			await commands.executeCommand('testing.cancelTestRefresh').then(() => {
-				log.info('testing.cancelTestRefresh completed')
-				return
-			}, (e: unknown) => {
-				log.error('testing.cancelTestRefresh caught an exception. e=' + e)
-				throw e
-			})
-			log.info(' - elapsedCancelTime=' + startCancelTime.elapsed() + 'ms, elapsedRefreshTime=' +  startRefreshTime.elapsed() + 'ms')
-			assert.durationMoreThan(startCancelTime, minCancelTime)
-			assert.durationLessThan(startCancelTime, maxCancelTime)
-			assert.durationLessThan(startRefreshTime, maxRefreshTime)
-		} catch (e: unknown) {
-			assert.fail('unexpected error: ' + e)
-		}
+		await commands.executeCommand('testing.cancelTestRefresh').then(() => {
+			log.info('testing.cancelTestRefresh completed')
+			return
+		}, (e: unknown) => {
+			log.error('testing.cancelTestRefresh caught an exception. e=' + e)
+			throw e
+		})
+		log.info(' - elapsedCancelTime=' + startCancelTime.elapsed() + 'ms, elapsedRefreshTime=' +  startRefreshTime.elapsed() + 'ms')
+		assert.durationMoreThan(startCancelTime, minCancelTime)
+		assert.durationLessThan(startCancelTime, maxCancelTime)
+		assert.durationLessThan(startRefreshTime, maxRefreshTime)
 
 		const ablfileCount = await getTestControllerItemCount('ABLTestFile')
 		log.info('controller file count after refresh = ' + ablfileCount)
 		assert.assert(ablfileCount > 1 && ablfileCount < 1000, 'ablfileCount should be > 1 and < 500, but is ' + ablfileCount)
 
-		await refresh.then(() => {
+		const prom = refresh.then(() => {
 			assert.fail('testing.refreshTests completed without throwing CancellationError')
 			return
 		}, (e: unknown) => {
@@ -64,6 +60,7 @@ suite('proj7B - Extension Test Suite', () => {
 				assert.equal(err.name, 'Canceled', 'testing.refreshTests threw unexpected error. Expected e.name="Canceled" e=' + e)
 			}
 		})
+		await prom
 	})
 
 	test('proj7B.2 - cancel test run while adding tests', async () => {

--- a/test/suites/proj9.test.ts
+++ b/test/suites/proj9.test.ts
@@ -1,4 +1,5 @@
-import { assert, deleteFile, deleteTestFiles, getTestCount, getWorkspaceUri, log, runAllTests, selectProfile, suiteSetupCommon, updateTestProfile, Uri, workspace } from '../testCommon'
+import { assert, deleteTestFiles, getTestCount, getWorkspaceUri, log, runAllTests, selectProfile, suiteSetupCommon, updateTestProfile, Uri, workspace } from '../testCommon'
+import * as FileUtils from '../../src/FileUtils'
 
 const testProfileJson = Uri.joinPath(getWorkspaceUri(), '.vscode/ablunit-test-profile.json')
 const testProfileBackup = Uri.joinPath(getWorkspaceUri(), '.vscode/ablunit-test-profile.json.backup')
@@ -13,13 +14,13 @@ suite('proj9 - Extension Test Suite', () => {
 
 	setup('proj9 - beforeEach', () => {
 		const workspaceFolder = workspace.workspaceFolders![0].uri
-		deleteFile(Uri.joinPath(workspaceFolder, '.vscode', 'profile.json'))
+		FileUtils.deleteFile(Uri.joinPath(workspaceFolder, '.vscode', 'profile.json'))
 		deleteTestFiles()
 		return
 	})
 
 	teardown('proj9 - afterEach', async () => {
-		deleteFile(testProfileJson)
+		FileUtils.deleteFile(testProfileJson)
 		await workspace.fs.copy(testProfileBackup, testProfileJson, { overwrite: true })
 		// await workspace.fs.copy(testProfileBackup, testProfileJson, { overwrite: true }).then(() => {
 		// 	log.info('teardown return')

--- a/test/suites/workspace0.test.ts
+++ b/test/suites/workspace0.test.ts
@@ -1,6 +1,4 @@
-import { strict as assert } from 'assert'
-import { Uri } from 'vscode'
-import { doesDirExist, doesFileExist, getWorkspaceFolders, runAllTests, suiteSetupCommon } from '../testCommon'
+import { assert, getWorkspaceFolders, runAllTests, suiteSetupCommon, Uri } from '../testCommon'
 
 suite('workspace0 - Extension Test Suite', () => {
 
@@ -18,10 +16,10 @@ suite('workspace0 - Extension Test Suite', () => {
 		const resultsJson = Uri.joinPath(workspaceFolder, 'results.json')
 		const listingsDir = Uri.joinPath(workspaceFolder, 'listings')
 
-		assert(doesFileExist(ablunitJson), 'missing ablunit.json (' + ablunitJson.fsPath + ')')
-		assert(doesFileExist(resultsXml), 'missing results.xml (' + resultsXml.fsPath + ')')
-		assert(!doesFileExist(resultsJson), 'results.json exists and should not (' + resultsJson.fsPath + ')')
-		assert(!doesDirExist(listingsDir), 'listings dir exists and should not (' + listingsDir.fsPath + ')')
+		assert.fileExists(ablunitJson)
+		assert.fileExists(resultsXml)
+		assert.fileExists(resultsJson, 'results.json exists and should not (' + resultsJson.fsPath + ')')
+		assert.dirExists(listingsDir, 'listings dir exists and should not (' + listingsDir.fsPath + ')')
 	})
 
 })

--- a/test/suites/workspace0.test.ts
+++ b/test/suites/workspace0.test.ts
@@ -18,8 +18,8 @@ suite('workspace0 - Extension Test Suite', () => {
 
 		assert.fileExists(ablunitJson)
 		assert.fileExists(resultsXml)
-		assert.fileExists(resultsJson, 'results.json exists and should not (' + resultsJson.fsPath + ')')
-		assert.dirExists(listingsDir, 'listings dir exists and should not (' + listingsDir.fsPath + ')')
+		assert.notFileExists(resultsJson)
+		assert.notDirExists(listingsDir)
 	})
 
 })


### PR DESCRIPTION
The main purpose of this is to avoid any imports from `extension.ts` which negatively affects unit testing because the extension appears active when not actually true.  It's also sort of a circular dependency which is 🍝