### PR TITLE
Add OpenEdge 12.8.5 test target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
     default: 12.8.1
   latest-oe-version:
     type: string
-    default: 12.8.4
+    default: 12.8.5
   prerelease-from-branch:
     type: string
     default: main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [1.0.6005](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.0.6005) - 2025-02-02
+
+
+ * Add OpenEdge 12.8.5 test target (#240)
+
+
+**Full Changelog**: [1.0.6003...1.0.6005](https://github.com/kenherring/ablunit-test-runner/compare/1.0.6003...1.0.6005)
+
 # [1.0.6003](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.0.6003) - 2025-01-27
 
 

--- a/docker/docker_build.sh
+++ b/docker/docker_build.sh
@@ -39,7 +39,8 @@ initialize () {
 		# DOCKER_TAGS+=('12.7.0')
 		DOCKER_TAGS+=('12.8.1')
 		# DOCKER_TAGS+=('12.8.3')
-		DOCKER_TAGS+=('12.8.4')
+		# DOCKER_TAGS+=('12.8.4')
+		DOCKER_TAGS+=('12.8.5')
 	fi
 
 	mkdir -p docker/.rssw

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -3,7 +3,7 @@ set -eou pipefail
 
 usage () {
 	echo "
-usage: $0 [ -o (12.2.12 | 12.7.0 | 12.8.1 | 12.8.3 | 12.8.4 | all) ] [ -V (stable | proposedapi | insiders | X.Y.Z] )] [ -p <project_name> ] [-bBimPv]
+usage: $0 [ -o (12.2.12 | 12.7.0 | 12.8.1 | 12.8.3 | 12.8.4 | 12.8.5 | all) ] [ -V (stable | proposedapi | insiders | X.Y.Z] )] [ -p <project_name> ] [-bBimPv]
 options:
   -o <version>  OE version (default: 12.8.1)
                 alternative: set the ABLUNIT_TEST_RUNNER_OE_VERSION environment variable
@@ -128,12 +128,13 @@ initialize () {
 	fi
 
 	if [ "${ABLUNIT_TEST_RUNNER_OE_VERSION,,}" = "all" ]; then
-		OE_VERSIONS=(12.2.12 12.7.0 12.8.1 12.8.3 12.8.4)
+		OE_VERSIONS=(12.2.12 12.7.0 12.8.1 12.8.3 12.8.4 12.8.5)
 	elif [ "$ABLUNIT_TEST_RUNNER_OE_VERSION" != '12.2.12' ] &&
 		[ "$ABLUNIT_TEST_RUNNER_OE_VERSION" != '12.7.0' ] &&
 		[ "$ABLUNIT_TEST_RUNNER_OE_VERSION" != '12.8.1' ] &&
 		[ "$ABLUNIT_TEST_RUNNER_OE_VERSION" != '12.8.3' ] &&
-		[ "$ABLUNIT_TEST_RUNNER_OE_VERSION" != '12.8.4' ]; then
+		[ "$ABLUNIT_TEST_RUNNER_OE_VERSION" != '12.8.4' ] &&
+		[ "$ABLUNIT_TEST_RUNNER_OE_VERSION" != '12.8.5' ]; then
 		echo "Invalid OE version: $ABLUNIT_TEST_RUNNER_OE_VERSION" >&2
 		usage && exit 1
 	else

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ablunit-test-runner",
-	"version": "1.0.6003",
+	"version": "1.0.6005",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ablunit-test-runner",
-			"version": "1.0.6003",
+			"version": "1.0.6005",
 			"license": "MIT",
 			"dependencies": {
 				"minimatch": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ablunit-test-runner",
 	"displayName": "ABLUnit Test Runner",
 	"description": "OpenEdge ABLUnit test runner for VSCode",
-	"version": "1.0.6003",
+	"version": "1.0.6005",
 	"preview": true,
 	"engineStrict": true,
 	"galleryBanner": {


### PR DESCRIPTION
* Add OpenEdge [12.8.5](https://github.com/progress/ADE/tree/v12.8.5.0) as a test target
* Remove 12.8.4, though it remains available if needed.

## 🔗 Links

* [DockerHub - progresssoftware/prgs-pasoe:12.8.5](https://hub.docker.com/layers/progresssoftware/prgs-pasoe/12.8.5/images/sha256-0d7ccb1c067a86202ff0c8555001c589d3bb289ea6ea59d7bf3cbd7fdc269864)