### PR TITLE
Fix regression related to path separators when displaying test class results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [1.0.6027](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.0.6027) - 2025-02-15
+
+
+ * Fix regression related to path separators when displaying test class results (#250)
+
+
+**Full Changelog**: [1.0.6025...1.0.6027](https://github.com/kenherring/ablunit-test-runner/compare/1.0.6025...1.0.6027)
+
 # [1.0.6025](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.0.6025) - 2025-02-15
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ablunit-test-runner",
-	"version": "1.0.6025",
+	"version": "1.0.6027",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ablunit-test-runner",
-			"version": "1.0.6025",
+			"version": "1.0.6027",
 			"license": "MIT",
 			"dependencies": {
 				"minimatch": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ablunit-test-runner",
 	"displayName": "ABLUnit Test Runner",
 	"description": "OpenEdge ABLUnit test runner for VSCode",
-	"version": "1.0.6025",
+	"version": "1.0.6027",
 	"preview": true,
 	"engineStrict": true,
 	"galleryBanner": {

--- a/src/ABLResults.ts
+++ b/src/ABLResults.ts
@@ -411,9 +411,8 @@ export class ABLResults implements Disposable {
 			const propathRelativePath = this.propath.search(suitePath)
 			const res = propathRelativePath
 			if (res?.propathRelativeFile) {
-				return res.propathRelativeFile
+				suitePath =  res.propathRelativeFile
 			}
-			return suitePath
 		}
 		suitePath = suitePath.replace(/\\/g, '/')
 		return suitePath

--- a/test/suites/proj0.test.ts
+++ b/test/suites/proj0.test.ts
@@ -446,4 +446,11 @@ suite('proj0  - Extension Test Suite', () => {
 		assert.linesNotExecuted('src/overloadedMethods.cls', [21])
 	})
 
+	test('proj0.22 - test coverage for class in subdirectory', async () => {
+		await runTestsInFile('src/dirA/dir1/testClassInDir.cls', 1, true)
+		assert.tests.count(2)
+		assert.tests.passed(2)
+		assert.tests.failed(0)
+	})
+
 })


### PR DESCRIPTION
This was the associated error seen in the logs:

```
could not find test suite for 'dirA\dir1\testClassInDir.cls' in results (item=dirA.dir1.testClassInDir)
```
