### PR TITLE
Add `debugConnectMaxWait` to test profile configuration options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,6 +14,7 @@ body:
       description: What version of the extension are you using?
       options:
         - 1.1.5
+        - 1.1.7
         - 1.1.3
         - 1.1.1
         - 1.1.0

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -17,6 +17,7 @@ body:
       description: What version of the extension are you using?
       options:
         - 1.1.5
+        - 1.1.7
         - 1.1.3
         - 1.1.1
         - 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [1.1.7](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.1.7) - 2025-03-27 (pre-release)
+
+
+ * Add `debugConnectMaxWait` to test profile configuration options (#266)
+ * Exception call stacks (#263)
+ * Improve parsing and display of test output (#262)
+
+**Full Changelog**: [1.1.3...1.1.7](https://github.com/kenherring/ablunit-test-runner/compare/1.1.3...1.1.7)
+
 # [1.1.3](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.1.3) - 2025-03-27 (pre-release)
 
  * Exception call stacks (#263)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ablunit-test-runner",
-	"version": "1.1.5",
+	"version": "1.1.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ablunit-test-runner",
-			"version": "1.1.5",
+			"version": "1.1.7",
 			"license": "MIT",
 			"dependencies": {
 				"minimatch": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ablunit-test-runner",
 	"displayName": "ABLUnit Test Runner",
 	"description": "OpenEdge ABLUnit test runner for VSCode",
-	"version": "1.1.5",
+	"version": "1.1.7",
 	"engineStrict": true,
 	"galleryBanner": {
 		"color": "#007ACC",

--- a/resources/VSCodeTestRunner/ABLUnitCore.p
+++ b/resources/VSCodeTestRunner/ABLUnitCore.p
@@ -62,9 +62,11 @@ procedure waitForDebuggerVisible :
 		return.
 
 	etime(yes).
-	do while etime < 10000 and debugger:visible = false:
+	define variable maxWait as integer init 10000 no-undo.
+	maxWait = integer(os-getenv('ABLUNIT_TEST_RUNNER_DEBUG_MAX_WAIT')) no-error.
+	do while etime < maxWait and debugger:visible = false:
 		// wait for 10 seconds
-		message 'waiting for debugger to connect... (' + string(etime) + '/10000ms)'.
+		message 'waiting for debugger to connect... (' + string(etime) + '/' + string(maxWait) + 'ms)'.
 		pause 1.
 	end.
 

--- a/resources/ablunit-test-profile.detail.jsonc
+++ b/resources/ablunit-test-profile.detail.jsonc
@@ -61,6 +61,9 @@
 			////# Port for connecting the debugger to the test run process using the '-debugReady <port>' startup parameter.
 			"debugPort": 3199,
 
+			////# Max time to wait for a connection on the debug port before continuing to run tests.
+			"debugConnectMaxWait": 10000,
+
 			////# These parameters will be passed to the command line.  Most commonly
 			////# this would be used to provide database connection parameters.
 			////# "additionalArgs": [

--- a/resources/ablunit-test-profile.schema.json
+++ b/resources/ablunit-test-profile.schema.json
@@ -264,6 +264,12 @@
 								"minimum": 0,
 								"description": "Port to use for debugging."
 							},
+							"debugConnectMaxWait": {
+								"type": "integer",
+								"default": 10000,
+								"minimum": 1000,
+								"description": "Max time to wait for a connection to the debug port."
+							},
 							"additionalArgs": {
 								"type": "array",
 								"default": [],

--- a/src/ABLUnitRun.ts
+++ b/src/ABLUnitRun.ts
@@ -210,7 +210,7 @@ function runCommand (res: ABLResults, options: TestRun, cancellation: Cancellati
 
 	return new Promise<string>((resolve, reject) => {
 		res.setStatus(RunStatus.Running)
-		const runenv = getEnvVars(res.dlc.uri)
+		const runenv = getEnvVars(res.dlc.uri, res.cfg.ablunitConfig.command.debugConnectMaxWait)
 		const compilerErrors: ICompilerError[] = []
 		let timeout = res.cfg.ablunitConfig.timeout
 		if (res.cfg.requestKind == TestRunProfileKind.Debug) {
@@ -412,7 +412,7 @@ function setCurrentTestItem (ablunitStatus: IABLUnitStatus) {
 	}
 }
 
-export function getEnvVars (dlcUri: Uri | undefined) {
+export function getEnvVars (dlcUri: Uri | undefined, maxWait = 10000) {
 	const runenv = process.env
 	let envConfig: Record<string, string> | undefined = undefined
 	if (process.platform === 'win32') {
@@ -434,5 +434,6 @@ export function getEnvVars (dlcUri: Uri | undefined) {
 	if (dlcUri) {
 		runenv['DLC'] = dlcUri.fsPath.replace(/\\/g, '/')
 	}
+	runenv['ABLUNIT_TEST_RUNNER_DEBUG_MAX_WAIT'] = maxWait.toString()
 	return runenv
 }

--- a/src/parse/config/CommandOptions.ts
+++ b/src/parse/config/CommandOptions.ts
@@ -5,6 +5,7 @@ export interface ICommandOptions {
 	batch: boolean | undefined
 	debugHost: string | undefined
 	debugPort: number | undefined
+	debugConnectMaxWait: number | undefined
 	additionalArgs: string[] | undefined
 }
 
@@ -14,6 +15,7 @@ export class CommandOptions implements ICommandOptions {
 	batch = true
 	debugHost = 'localhost'
 	debugPort = 3199
+	debugConnectMaxWait = 10000
 	additionalArgs: string[] = []
 
 	constructor (from?: ICommandOptions) {
@@ -25,6 +27,7 @@ export class CommandOptions implements ICommandOptions {
 		this.batch = from.batch ?? this.batch
 		this.debugHost = from.debugHost ?? this.debugHost
 		this.debugPort = from.debugPort ?? this.debugPort
+		this.debugConnectMaxWait = from.debugConnectMaxWait ?? this.debugConnectMaxWait
 		this.additionalArgs = from.additionalArgs ?? this.additionalArgs
 	}
 }

--- a/test_projects/proj0/.vscode/ablunit-test-profile.json
+++ b/test_projects/proj0/.vscode/ablunit-test-profile.json
@@ -2,16 +2,10 @@
 	"configurations": [
 		{
 			"tempDir": "${workspaceFolder}",
-			"importOpenedgeProjectJson": true,
-			"timeout": 30000,
 			"command": {
 				"executable": "_progres",
 				"progressIni": "progress.ini",
-				"batch": true,
-				"debugHost": "localhost",
-				"debugPort": 3199,
-				"debugConnectMaxWait": 10000,
-				"additionalArgs": []
+				"debugConnectMaxWait": 30000
 			},
 			"options": {
 				"output": {
@@ -20,17 +14,9 @@
 					"format": "xml",
 					"updateFile": "updates.log"
 				},
-				"debug": false,
 				"quitOnEnd": true,
-				"writeLog": false,
 				"showErrorMessage": true,
-				"throwError": true,
-				"xref": {
-					"useXref": false,
-					"xrefLocation": "${tempDir}",
-					"xrefExtension": "xml.xref",
-					"xrefThrowError": false
-				}
+				"throwError": true
 			},
 			"profiler": {
 				"enabled": true,


### PR DESCRIPTION
Workspaces with a large number of r-code files may need more than 10s for the debugger to start.