### PR TITLE
Display warning for missing `[BLOCK|ROUTINE]-LEVEL ON ERROR` statement

### DIFF
--- a/.circleci/sonar.sh
+++ b/.circleci/sonar.sh
@@ -63,8 +63,6 @@ pre_scan () {
     scripts/sonar_test_results_merge.sh
     ## remove base dir of /home/circleci/project/
     sed -i 's|/home/circleci/project||g' artifacts/eslint_report.json
-    jq . artifacts/eslint_report.json > artifacts/eslint_report_pretty.json
-
 }
 
 sonarcloud_scan () {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
-# [1.2.11](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.2.11) - 2025-05-14 (pre-release)
+# [1.2.13](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.2.13) - 2025-05-14 (pre-release)
 
- * Display warning for missing [BLOCK|ROUTINE]-LEVEL ON ERROR statement (#290)
- * Remove creation of .bin files (#289)
- * Add OpenEdge 12.8.7 test target (#287)
- * Warn when rcode CRC does not match profiler CRC (#272)
- * Create codeql.yml (#278)
- * Create dependabot.yml (#275)
- * Bump the npm_and_yarn group across 1 directory with 2 updates (#277)
- * Update eslint configuration (#279)
- * Unit test cleanup and performance (#274)
- * Increase debug profile wait time to 30s (part 2) (#273)
+* Display warning for missing `[BLOCK|ROUTINE]-LEVEL ON ERROR` statement (#290)
+* Update changelog updater (#291)
+* Remove creation of `.bin` files (#289)
+* Add OpenEdge 12.8.7 test target (#287)
+* Bump mocha from 11.1.0 to 11.2.2 (#286)
+* Warn when rcode CRC does not match profiler CRC (#272)
+* Bump dependencies (#285)
+* Create codeql.yml (#278)
+* Create dependabot.yml (#275)
+* Bump the npm_and_yarn group across 1 directory with 2 updates (#277)
+* Update eslint configuration (#279)
+* Unit test cleanup and performance (#274)
+* Bump braces from 3.0.2 to 3.0.3 in /dummy-ext in the npm_and_yarn group across 1 directory (#276)
+* Increase debug profile wait time to 30s (part 2) (#273)
 
-**Full Changelog**: [1.2.0...1.2.11](https://github.com/kenherring/ablunit-test-runner/compare/1.2.0...1.2.11)
+**Full Changelog**: [1.2.0...1.2.13](https://github.com/kenherring/ablunit-test-runner/compare/1.2.11...1.2.13)
 
 # [1.2.0](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.2.0) - 2025-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 # [1.2.11](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.2.11) - 2025-05-14 (pre-release)
 
-
- * 
-
-
-**Full Changelog**: [1.2.9...1.2.11](https://github.com/kenherring/ablunit-test-runner/compare/1.2.9...1.2.11)
-
-# [1.2.9](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.2.9) - 2025-05-13 (pre-release)
-
+ * Display warning for missing [BLOCK|ROUTINE]-LEVEL ON ERROR statement (#290)
  * Add OpenEdge 12.8.7 test target (#287)
  * Warn when rcode CRC does not match profiler CRC (#272)
  * Create codeql.yml (#278)
@@ -17,7 +10,7 @@
  * Unit test cleanup and performance (#274)
  * Increase debug profile wait time to 30s (part 2) (#273)
 
-**Full Changelog**: [1.2.0...1.2.9](https://github.com/kenherring/ablunit-test-runner/compare/1.2.0...1.2.9)
+**Full Changelog**: [1.2.0...1.2.11](https://github.com/kenherring/ablunit-test-runner/compare/1.2.0...1.2.11)
 
 # [1.2.0](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.2.0) - 2025-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [1.2.11](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.2.11) - 2025-05-14 (pre-release)
+
+
+ * 
+
+
+**Full Changelog**: [1.2.9...1.2.11](https://github.com/kenherring/ablunit-test-runner/compare/1.2.9...1.2.11)
+
 # [1.2.9](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.2.9) - 2025-05-13 (pre-release)
 
  * Add OpenEdge 12.8.7 test target (#287)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # [1.2.11](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.2.11) - 2025-05-14 (pre-release)
 
-
- * Add OpenEdge 12.8.7 test target (#287)
+ * Display warning for missing [BLOCK|ROUTINE]-LEVEL ON ERROR statement (#290)
  * Remove creation of .bin files (#289)
+ * Add OpenEdge 12.8.7 test target (#287)
  * Warn when rcode CRC does not match profiler CRC (#272)
  * Create codeql.yml (#278)
  * Create dependabot.yml (#275)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ablunit-test-runner",
-	"version": "1.2.9",
+	"version": "1.2.11",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ablunit-test-runner",
-			"version": "1.2.9",
+			"version": "1.2.11",
 			"license": "MIT",
 			"dependencies": {
 				"minimatch": "^10.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ablunit-test-runner",
-	"version": "1.2.11",
+	"version": "1.2.13",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ablunit-test-runner",
-			"version": "1.2.11",
+			"version": "1.2.13",
 			"license": "MIT",
 			"dependencies": {
 				"minimatch": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ablunit-test-runner",
 	"displayName": "ABLUnit Test Runner",
 	"description": "OpenEdge ABLUnit test runner for VSCode",
-	"version": "1.2.11",
+	"version": "1.2.13",
 	"engineStrict": true,
 	"galleryBanner": {
 		"color": "#007ACC",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ablunit-test-runner",
 	"displayName": "ABLUnit Test Runner",
 	"description": "OpenEdge ABLUnit test runner for VSCode",
-	"version": "1.2.9",
+	"version": "1.2.11",
 	"engineStrict": true,
 	"galleryBanner": {
 		"color": "#007ACC",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.tests=test
 sonar.test.inclusions=test/**
 
 sonar.coverage.exclusions=*.json,esbuild.js
-sonar.eslint.reportPaths=artifacts/eslint_report_pretty.json
+sonar.eslint.reportPaths=artifacts/eslint_report.json
 sonar.javascript.lcov.reportPaths=artifacts/coverage/lcov.info
 sonar.testExecutionReportPaths=artifacts/mocha_results_sonar_merged.xml
 

--- a/src/testTree.ts
+++ b/src/testTree.ts
@@ -341,12 +341,14 @@ function hasUndoThrowParameter (uri: Uri) {
 	return false
 }
 
-function manageDiagnostic (uri: Uri, missingOnError: boolean) {
+function manageDiagnostic (uri: Uri | undefined, missingOnError: boolean) {
+	if (!uri) {
+		return
+	}
 	if (!missingOnError || hasUndoThrowParameter(uri)) {
 		diagCollection.delete(uri)
 		return
 	}
-
 	if (diagCollection.has(uri)) {
 		return
 	}
@@ -383,11 +385,7 @@ export class ABLTestClass extends ABLTestFile {
 		this.startParsing(item)
 		const response = parseABLTestClass(displayClassLabel, content, this.relativePath)
 		this.updateItem(controller, item, response, 'Method')
-
-		if (item.uri) {
-			manageDiagnostic(item.uri, response?.missingOnError ?? false)
-		}
-
+		manageDiagnostic(item.uri, response?.missingOnError ?? false)
 		this.setClassInfo(response?.classname)
 		return item.children.size > 0
 	}
@@ -402,11 +400,7 @@ export class ABLTestProgram extends ABLTestFile {
 	public override updateFromContents (controller: TestController, content: string, item: TestItem) {
 		this.startParsing(item)
 		const response = parseABLTestProgram(content, this.relativePath)
-
-		if (item.uri) {
-			manageDiagnostic(item.uri, response?.missingOnError ?? false)
-		}
-
+		manageDiagnostic(item.uri, response?.missingOnError ?? false)
 		this.updateItem(controller, item, response, 'Procedure')
 		return item.children.size > 0
 	}

--- a/src/testTree.ts
+++ b/src/testTree.ts
@@ -1,13 +1,18 @@
-import { CancellationError, CancellationToken, Range, TestController, TestItem, TestRun, TestTag, Uri, workspace } from 'vscode'
+import { CancellationError, CancellationToken, DiagnosticSeverity, languages, Range, TestController, TestItem, TestRun, TestTag, Uri, workspace, WorkspaceFolder } from 'vscode'
 import { ABLResults } from 'ABLResults'
 import { parseABLTestSuite } from 'parse/TestSuiteParser'
 import { IClassRet, ITestCase, parseABLTestClass } from 'parse/TestClassParser'
 import { IProgramRet, parseABLTestProgram } from 'parse/TestProgramParser'
 import { getContentFromFilesystem } from 'parse/TestParserCommon'
 import { log } from 'ChannelLogger'
+import { getExtraParameters } from 'parse/OpenedgeProjectParser'
+import { getProfileConfig } from 'parse/TestProfileParser'
 
 export type ABLTestData = ABLTestDir | ABLTestFile | ABLTestCase
 export const resultData = new WeakMap<TestRun, ABLResults[]>()
+
+const diagCollection = languages.createDiagnosticCollection('ablunit')
+const undothrowMap = new WeakMap<WorkspaceFolder, boolean>()
 
 class TestData {
 	private readonly td: WeakMap<TestItem, ABLTestData> = new WeakMap<TestItem, ABLTestData>()
@@ -309,6 +314,58 @@ export class ABLTestSuite extends ABLTestFile {
 	}
 }
 
+function hasUndoThrowParameter (uri: Uri) {
+	const workspaceFolder = workspace.getWorkspaceFolder(uri)
+	if (workspaceFolder?.uri) {
+
+		const mapValue = undothrowMap.get(workspaceFolder)
+		if (mapValue !== undefined) {
+			return mapValue
+		}
+
+		const params = getExtraParameters(workspaceFolder.uri) ?? ''
+		if (params.includes('undothrow')) {
+			undothrowMap.set(workspaceFolder, true)
+			return true
+		}
+
+		const profile = getProfileConfig(workspaceFolder)
+		if (profile.command.additionalArgs.includes('undothrow')) {
+			undothrowMap.set(workspaceFolder, true)
+			return true
+		}
+
+		undothrowMap.set(workspaceFolder, false)
+	}
+
+	return false
+}
+
+function manageDiagnostic (uri: Uri, missingOnError: boolean) {
+	if (!missingOnError || hasUndoThrowParameter(uri)) {
+		diagCollection.delete(uri)
+		return
+	}
+
+	if (diagCollection.has(uri)) {
+		return
+	}
+
+	diagCollection.set(uri, [
+		{
+			message: 'Missing `[BLOCK | ROUTINE]-LEVEL ON ERROR` statement' +
+				'\nWithout this statement `OpenEdge.Core.Assert` failures will not be caught and reported as test failures.',
+			code: {
+				value: 'Run test cases and test suites',
+				target: Uri.parse('https://docs.progress.com/bundle/openedge-developer-studio-help/page/Run-test-cases-and-test-suites.html')
+			},
+			severity: DiagnosticSeverity.Warning,
+			range: new Range(0, 0, 0, 0),
+			source: 'ablunit',
+		}
+	])
+}
+
 export class ABLTestClass extends ABLTestFile {
 	public classTypeName = ''
 
@@ -327,6 +384,10 @@ export class ABLTestClass extends ABLTestFile {
 		const response = parseABLTestClass(displayClassLabel, content, this.relativePath)
 		this.updateItem(controller, item, response, 'Method')
 
+		if (item.uri) {
+			manageDiagnostic(item.uri, response?.missingOnError ?? false)
+		}
+
 		this.setClassInfo(response?.classname)
 		return item.children.size > 0
 	}
@@ -341,6 +402,11 @@ export class ABLTestProgram extends ABLTestFile {
 	public override updateFromContents (controller: TestController, content: string, item: TestItem) {
 		this.startParsing(item)
 		const response = parseABLTestProgram(content, this.relativePath)
+
+		if (item.uri) {
+			manageDiagnostic(item.uri, response?.missingOnError ?? false)
+		}
+
 		this.updateItem(controller, item, response, 'Procedure')
 		return item.children.size > 0
 	}

--- a/test/createTestConfig.mjs
+++ b/test/createTestConfig.mjs
@@ -83,7 +83,7 @@ function getMochaOpts (projName) {
 		bail: true,
 		require: [
 			'mocha',
-			// 'esbuild-register',
+			'esbuild-register',
 			'tsconfig-paths/register',
 			'@swc-node/register',
 		],

--- a/test/createTestConfig.mjs
+++ b/test/createTestConfig.mjs
@@ -83,7 +83,7 @@ function getMochaOpts (projName) {
 		bail: true,
 		require: [
 			'mocha',
-			'esbuild-register',
+			// 'esbuild-register',
 			'tsconfig-paths/register',
 			'@swc-node/register',
 		],

--- a/test_projects/proj0/src/blockLevelMissing.p
+++ b/test_projects/proj0/src/blockLevelMissing.p
@@ -1,0 +1,6 @@
+routine-level on    error     undo,throw.
+
+@Test.
+procedure procedureName :
+    OpenEdge.Core.Assert:Equals(1, 2).
+end procedure.


### PR DESCRIPTION
Warning will not be created when the `-undothrow` parameter exists as a startup parameter in one of the `ablunit-test-profile.json` or `openedge-project.json` configurations.