### PR TITLE
Add support to override session:parameter

### DIFF
--- a/resources/VSCodeTestRunner/ABLUnitCore.p
+++ b/resources/VSCodeTestRunner/ABLUnitCore.p
@@ -1,0 +1,10 @@
+// This file replaces the standard ABLUnitCore.p when the basedir is
+// included as part of the propath ahead of ablunit.pl.
+
+block-level on error undo, throw.
+
+define variable thisProcDir as character no-undo.
+thisProcDir = replace(program-name(1), '~\', '/').
+entry(num-entries(thisProcDir, '/'), thisProcDir, '/') = ''.
+
+run value(thisProcDir + "ABLUnitCore_sub.p")(session:parameter).

--- a/resources/VSCodeTestRunner/ABLUnitCore_sub.p
+++ b/resources/VSCodeTestRunner/ABLUnitCore_sub.p
@@ -4,6 +4,8 @@
 block-level on error undo, throw.
 create widget-pool.
 
+define input parameter sessionParameter as character no-undo.
+
 define variable testConfig as class OpenEdge.ABLUnit.Runner.TestConfig no-undo.
 define variable quitOnEnd as logical init false no-undo.
 define variable VERBOSE as logical no-undo.
@@ -116,10 +118,10 @@ procedure main :
 	if VERBOSE then message 'START main'.
 
 	session:suppress-warnings = true.
-	run VSCode/createDatabaseAliases.p(VERBOSE).
+	run VSCode/createDatabaseAliases.p(VERBOSE, sessionParameter).
 
-	assign updateFile = getParameter(trim(trim(session:parameter,'"'),"'"), 'ATTR_ABLUNIT_EVENT_FILE').
-	testConfig = readTestConfig(getParameter(trim(trim(session:parameter,'"'),"'"), 'CFG')).
+	assign updateFile = getParameter(trim(trim(sessionParameter,'"'),"'"), 'ATTR_ABLUNIT_EVENT_FILE').
+	testConfig = readTestConfig(getParameter(trim(trim(sessionParameter,'"'),"'"), 'CFG')).
 	quitOnEnd = (testConfig = ?) or testConfig:quitOnEnd.
 
 	define variable initializationProcedure as character no-undo.

--- a/resources/VSCodeTestRunner/VSCode/createDatabaseAliases.p
+++ b/resources/VSCodeTestRunner/VSCode/createDatabaseAliases.p
@@ -1,5 +1,6 @@
 
 define input parameter VERBOSE as logical no-undo.
+define input parameter sessionParameter as character no-undo.
 
 define variable aliasesSessionParam as character no-undo.
 define variable paramStart as integer no-undo.
@@ -11,18 +12,18 @@ define variable aliasName as character no-undo.
 define variable databaseName as character no-undo.
 if VERBOSE then message 'START createDatabaseAliases'.
 
-if index(session:parameter,"ALIASES=") <= 0 then
+if index(sessionParameter,"ALIASES=") <= 0 then
 do:
-    if VERBOSE then message 'END createDatabaseAliases - no ALIASES in session:parameter'.
+    if VERBOSE then message 'END createDatabaseAliases - no ALIASES in sessionParameter'.
     return.
 end.
 
-assign paramStart = index(session:parameter,'ALIASES=') + 8.
-assign paramEnd = index(session:parameter,' ',paramStart).
+assign paramStart = index(sessionParameter,'ALIASES=') + 8.
+assign paramEnd = index(sessionParameter,' ',paramStart).
 if paramEnd = 0 then
-    paramEnd = length(session:parameter) + 1.
+    paramEnd = length(sessionParameter) + 1.
 
-assign aliasesSessionParam = substring(session:parameter, paramStart, paramEnd - paramStart).
+assign aliasesSessionParam = substring(sessionParameter, paramStart, paramEnd - paramStart).
 
 do dbCount = 1 to num-entries(aliasesSessionParam,';'):
     assign aliasList = entry(dbCount, aliasesSessionParam,';').


### PR DESCRIPTION
This change adds support to override `session:parameter` that was (hardcoded) used in `ABLUnitCore.p` and `createDatabaseAliases.p`.
Changes in ABL code only.
I've rerun all existing tests and all succeed, except for the ones that are supposed to fail 😉.
See #488 for a use case.