### PR TITLE
Clear environment variable when `initializationProcedure` is no longer set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 * Bump esbuild from 0.27.0 to 0.27.1 (#457)
 * Bump jws from 3.2.2 to 3.2.3 in the npm_and_yarn group across 1 directory (#455)
 
-**Full Changelog**: [1.4.4...1.4.33](https://github.com/kenherring/ablunit-test-runner/compare/1.4.31...1.4.33)
+**Full Changelog**: [1.4.4...1.4.33](https://github.com/kenherring/ablunit-test-runner/compare/1.4.4...1.4.33)
 
 # [1.4.4](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.4.4) - 2025-11-26 (pre-release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# [1.4.31](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.4.31) - 2026-04-09 (pre-release)
+# [1.4.33](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.4.33) - 2026-04-15 (pre-release)
 
+* Clear environment variable when `initializationProcedure` is no longer set (#565)
+* build(deps-dev): bump typescript-eslint from 8.58.0 to 8.58.1 (#563)
 * Empty `dbConnections` array in openedge-project profile are not used (#560)
 * Fix create-release action and a few lint errors (#559)
 * Allow `.exe` extension in the executable field for ablunit-test-profile.json (#558)
@@ -68,7 +70,7 @@
 * Bump esbuild from 0.27.0 to 0.27.1 (#457)
 * Bump jws from 3.2.2 to 3.2.3 in the npm_and_yarn group across 1 directory (#455)
 
-**Full Changelog**: [1.4.4...1.4.31](https://github.com/kenherring/ablunit-test-runner/compare/1.4.4...1.4.31)
+**Full Changelog**: [1.4.4...1.4.33](https://github.com/kenherring/ablunit-test-runner/compare/1.4.31...1.4.33)
 
 # [1.4.4](https://github.com/kenherring/ablunit-test-runner/releases/tag/1.4.4) - 2025-11-26 (pre-release)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ablunit-test-runner",
-	"version": "1.4.31",
+	"version": "1.4.33",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ablunit-test-runner",
-			"version": "1.4.31",
+			"version": "1.4.33",
 			"license": "MIT",
 			"dependencies": {
 				"minimatch": "^10.2.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ablunit-test-runner",
 	"displayName": "ABLUnit Test Runner",
 	"description": "OpenEdge ABLUnit test runner for VSCode",
-	"version": "1.4.31",
+	"version": "1.4.33",
 	"engineStrict": true,
 	"galleryBanner": {
 		"color": "#007ACC",

--- a/resources/VSCodeTestRunner/ABLUnitCore.p
+++ b/resources/VSCodeTestRunner/ABLUnitCore.p
@@ -125,7 +125,14 @@ procedure main :
 	define variable initializationProcedure as character no-undo.
 	initializationProcedure = os-getenv('ABLUNIT_INITIALIZATION_PROCEDURE').
 	if initializationProcedure <> ? and initializationProcedure > '' then
+	do:
+		if search(initializationProcedure) = ? then
+		do:
+			undo, throw new Progress.Lang.AppError('Initialization procedure ' + initializationProcedure + ' not found in PROPATH', 89).
+		end.
+
 		run value(initializationProcedure).
+	end.
 
 	run VSCode/ABLRunner-wrapper.p(testConfig, updateFile).
 	if VERBOSE then message 'END main'.
@@ -166,7 +173,7 @@ catch e as Progress.Lang.Error:
 		define variable i as integer no-undo.
 		do i = 1 to e:NumMessages:
 			message '[ABLRunner error]' e:GetMessage(i) view-as alert-box error.
-			if not e:GetMessage(1) begins 'Unable to build type info' then
+			if e:CallStack <> ? and not e:GetMessage(1) begins 'Unable to build type info' then
 			do:
 				message '[ABLRunner error]~t' + replace(e:CallStack, '~n', '~n[ABLRunner error]~t').
 			end.

--- a/src/ABLUnitRun.ts
+++ b/src/ABLUnitRun.ts
@@ -479,7 +479,7 @@ function setCurrentTestItem (ablunitStatus: IABLUnitStatus) {
 }
 
 export function getEnvVars (dlcUri: Uri | undefined, maxWait = 30000, initializationProcedure?: string) {
-	const runenv = process.env
+	const runenv = { ...process.env }
 	let envConfig: Record<string, string> | undefined = undefined
 	if (process.platform === 'win32') {
 		envConfig = workspace.getConfiguration('terminal').get('integrated.env.windows')
@@ -504,7 +504,7 @@ export function getEnvVars (dlcUri: Uri | undefined, maxWait = 30000, initializa
 	if (initializationProcedure) {
 		runenv['ABLUNIT_INITIALIZATION_PROCEDURE'] = initializationProcedure
 	} else {
-		runenv['ABLUNIT_INITIALIZATION_PROCEDURE'] = ''
+		delete runenv['ABLUNIT_INITIALIZATION_PROCEDURE']
 	}
 	return runenv
 }

--- a/src/ABLUnitRun.ts
+++ b/src/ABLUnitRun.ts
@@ -503,6 +503,8 @@ export function getEnvVars (dlcUri: Uri | undefined, maxWait = 30000, initializa
 	runenv['ABLUNIT_TEST_RUNNER_DEBUG_MAX_WAIT'] = maxWait.toString()
 	if (initializationProcedure) {
 		runenv['ABLUNIT_INITIALIZATION_PROCEDURE'] = initializationProcedure
+	} else {
+		runenv['ABLUNIT_INITIALIZATION_PROCEDURE'] = ''
 	}
 	return runenv
 }

--- a/test/suites/proj8.test.ts
+++ b/test/suites/proj8.test.ts
@@ -46,4 +46,21 @@ suite('proj8 - Extension Test Suite', () => {
 			})
 	})
 
+	test('proj8.3 - getEnvVars does not mutate process.env for initializationProcedure', () => {
+		const key = 'ABLUNIT_INITIALIZATION_PROCEDURE'
+		const original = process.env[key]
+		process.env[key] = 'original-value'
+		try {
+			const envVars = getEnvVars(undefined, 30000)
+			assert.strictEqual(envVars[key], undefined)
+			assert.strictEqual(process.env[key], 'original-value')
+		} finally {
+			if (original === undefined) {
+				delete process.env.ABLUNIT_INITIALIZATION_PROCEDURE
+			} else {
+				process.env[key] = original
+			}
+		}
+	})
+
 })


### PR DESCRIPTION
Fixes #494