### PR TITLE
Fix space-in-path errors and simplify session:parameter parsing

### DIFF
--- a/resources/VSCodeTestRunner/ABLUnitCore.p
+++ b/resources/VSCodeTestRunner/ABLUnitCore.p
@@ -17,15 +17,6 @@ return.
 
 // --------- FUNCTIONS ----------
 
-function getParameter returns character (input params as character, input name as character) :
-	define variable cnt as integer no-undo.
-	do cnt = 1 to num-entries(params,' '):
-		if entry(cnt,params,' ') begins name + '=' then
-			return entry(2, entry(cnt, params, ' '), '=').
-	end.
-	return ''.
-end function.
-
 function readTestConfig returns OpenEdge.ABLUnit.Runner.TestConfig (filepath as character) :
 	return new OpenEdge.ABLUnit.Runner.TestConfig(cast((new Progress.Json.ObjectModel.ObjectModelParser()):ParseFile(filepath), Progress.Json.ObjectModel.JsonObject)).
 end function.
@@ -113,13 +104,15 @@ end procedure.
 
 procedure main :
 	define variable updateFile as character no-undo.
+	define variable cfgFile as character no-undo.
 	if VERBOSE then message 'START main'.
 
 	session:suppress-warnings = true.
-	run VSCode/createDatabaseAliases.p(VERBOSE).
+	run VSCode/createDatabaseAliases.p(VERBOSE, session:parameter).
 
-	assign updateFile = getParameter(trim(trim(session:parameter,'"'),"'"), 'ATTR_ABLUNIT_EVENT_FILE').
-	testConfig = readTestConfig(getParameter(trim(trim(session:parameter,'"'),"'"), 'CFG')).
+	run VSCode/getSessionParameter.p(session:parameter, 'ATTR_ABLUNIT_EVENT_FILE', output updateFile).
+	run VSCode/getSessionParameter.p(session:parameter, 'CFG', output cfgFile).
+	testConfig = readTestConfig(cfgFile).
 	quitOnEnd = (testConfig = ?) or testConfig:quitOnEnd.
 
 	define variable initializationProcedure as character no-undo.

--- a/resources/VSCodeTestRunner/VSCode/createDatabaseAliases.p
+++ b/resources/VSCodeTestRunner/VSCode/createDatabaseAliases.p
@@ -1,34 +1,28 @@
-
 define input parameter VERBOSE as logical no-undo.
+define input parameter sessionParam as character no-undo.
 
 define variable aliasesSessionParam as character no-undo.
-define variable paramStart as integer no-undo.
-define variable paramEnd as integer no-undo.
 define variable dbCount as integer no-undo.
 define variable aliasCount as integer no-undo.
 define variable aliasList as character no-undo.
 define variable aliasName as character no-undo.
 define variable databaseName as character no-undo.
+
 if VERBOSE then message 'START createDatabaseAliases'.
 
-if index(session:parameter,"ALIASES=") <= 0 then
+run VSCode/getSessionParameter.p(sessionParam, 'ALIASES', output aliasesSessionParam).
+
+if aliasesSessionParam = '' or aliasesSessionParam = ? then
 do:
     if VERBOSE then message 'END createDatabaseAliases - no ALIASES in session:parameter'.
     return.
 end.
 
-assign paramStart = index(session:parameter,'ALIASES=') + 8.
-assign paramEnd = index(session:parameter,' ',paramStart).
-if paramEnd = 0 then
-    paramEnd = length(session:parameter) + 1.
+do dbCount = 1 to num-entries(aliasesSessionParam, ';'):
+    assign aliasList = entry(dbCount, aliasesSessionParam, ';').
+    assign databaseName = entry(1, aliasList).
 
-assign aliasesSessionParam = substring(session:parameter, paramStart, paramEnd - paramStart).
-
-do dbCount = 1 to num-entries(aliasesSessionParam,';'):
-    assign aliasList = entry(dbCount, aliasesSessionParam,';').
-    assign databaseName = entry(1,aliasList).
-
-    do aliasCount = 2 to num-entries(aliaslist,','):
+    do aliasCount = 2 to num-entries(aliasList, ','):
         assign aliasName = entry(aliasCount, aliasList).
         create alias value(aliasName) for database value(databaseName).
     end.

--- a/resources/VSCodeTestRunner/VSCode/generateDebugListing.p
+++ b/resources/VSCodeTestRunner/VSCode/generateDebugListing.p
@@ -25,7 +25,7 @@ end function.
 
 procedure main :
     run setPropath.
-    run VSCode/createDatabaseAliases.p(false).
+    run VSCode/createDatabaseAliases.p(false, session:parameter).
 
 	define variable sourceFile as character no-undo.
 	define variable rcodeDirectory as character no-undo.

--- a/resources/VSCodeTestRunner/VSCode/getSessionParameter.p
+++ b/resources/VSCodeTestRunner/VSCode/getSessionParameter.p
@@ -1,0 +1,26 @@
+block-level on error undo, throw.
+
+define input parameter params as character no-undo.
+define input parameter name as character no-undo.
+define output parameter val as character no-undo.
+
+define variable cnt as integer no-undo.
+define variable entryStr as character no-undo.
+
+/* 
+ * The 'params' input parameter is a pipe-delimited list of key-value pairs.
+ * Format: "KEY1=VALUE1|KEY2=VALUE2|KEY3=VALUE3"
+ * Example: "CFG=c:/path/ablunit.json|ALIASES=db1,alias1;db2,alias2"
+ */
+assign params = trim(trim(params, '"'), "'").
+
+assign val = "".
+
+do cnt = 1 to num-entries(params, '|'):
+    assign entryStr = entry(cnt, params, '|').
+    if entry(1, entryStr, '=') = name then
+    do:
+        assign val = entry(2, entryStr, '=').
+        return.
+    end.
+end.

--- a/src/ABLExec.ts
+++ b/src/ABLExec.ts
@@ -4,6 +4,7 @@ import { log } from 'ChannelLogger'
 import { ABLUnitConfig } from 'ABLUnitConfigWriter'
 import { IDlc } from 'parse/OpenedgeProjectParser'
 import { PropathParser } from 'ABLPropath'
+import * as FileUtils from 'FileUtils'
 
 let abort: AbortController
 
@@ -54,9 +55,9 @@ function getDefaultCommand (cfg: ABLUnitConfig, dlc: IDlc, propath: PropathParse
 		throw new Error('temp directory not set')
 	}
 
-	const executable = dlc.uri.fsPath.replace(/\\/g, '/') + '/bin/' + cfg.ablunitConfig.command.executable
+	const executable = FileUtils.quotePath(dlc.uri.fsPath + '/bin/' + cfg.ablunitConfig.command.executable)
 
-	const cmd = [ executable, '-p', execFile ]
+	const cmd = [ executable, '-p', FileUtils.quotePath(execFile) ]
 
 	if (cfg.ablunitConfig.command.batch) {
 		cmd.push('-b')
@@ -65,7 +66,7 @@ function getDefaultCommand (cfg: ABLUnitConfig, dlc: IDlc, propath: PropathParse
 	process.env['PROPATH'] = propath.toString().replace(/\$\{DLC\}/g, dlc.uri.fsPath.replace(/\\/g, '/'))
 
 	if (cfg.ablunitConfig.dbConnPfUri && cfg.ablunitConfig.dbConns && cfg.ablunitConfig.dbConns.length > 0) {
-		cmd.push('-pf', cfg.ablunitConfig.dbConnPfUri.fsPath)
+		cmd.push('-pf', FileUtils.quotePath(cfg.ablunitConfig.dbConnPfUri.fsPath))
 	}
 
 	const cmdSanitized: string[] = []

--- a/src/ABLUnitRun.ts
+++ b/src/ABLUnitRun.ts
@@ -126,9 +126,9 @@ function getDefaultCommand (res: ABLResults) {
 		throw new Error('temp directory not set')
 	}
 
-	const executable = res.dlc.uri.fsPath.replace(/\\/g, '/') + '/bin/' + res.cfg.ablunitConfig.command.executable
+	const executable = FileUtils.quotePath(res.dlc.uri.fsPath + '/bin/' + res.cfg.ablunitConfig.command.executable)
 
-	const cmd = [ executable, '-p', res.wrapperUri.fsPath.replace(/\\/g, '/') ]
+	const cmd = [ executable, '-p', FileUtils.quotePath(res.wrapperUri.fsPath) ]
 
 	if (res.cfg.ablunitConfig.command.batch) {
 		cmd.push('-b')
@@ -136,14 +136,14 @@ function getDefaultCommand (res: ABLResults) {
 
 	process.env['PROPATH'] = res.propath.toString().replace(/\$\{DLC\}/g, res.dlc.uri.fsPath.replace(/\\/g, '/'))
 
-	cmd.push('-T', res.cfg.ablunitConfig.tempDirUri.fsPath)
+	cmd.push('-T', FileUtils.quotePath(res.cfg.ablunitConfig.tempDirUri.fsPath))
 
 	if (res.cfg.ablunitConfig.dbConnPfUri && res.cfg.ablunitConfig.dbConns && res.cfg.ablunitConfig.dbConns.length > 0) {
-		cmd.push('-pf', res.cfg.ablunitConfig.dbConnPfUri.fsPath)
+		cmd.push('-pf', FileUtils.quotePath(res.cfg.ablunitConfig.dbConnPfUri.fsPath))
 	}
 
 	if (res.cfg.ablunitConfig.profiler.enabled && res.cfg.requestKind == TestRunProfileKind.Coverage) {
-		cmd.push('-profile', res.cfg.ablunitConfig.profOptsUri.fsPath)
+		cmd.push('-profile', FileUtils.quotePath(res.cfg.ablunitConfig.profOptsUri.fsPath))
 	} else if (res.cfg.requestKind == TestRunProfileKind.Debug) {
 		cmd.push('-debugReady', res.cfg.ablunitConfig.command.debugPort.toString())
 	}
@@ -151,12 +151,12 @@ function getDefaultCommand (res: ABLResults) {
 	const cmdSanitized: string[] = []
 	cmd.push(...res.cfg.ablunitConfig.command.additionalArgs)
 
-	let params = 'CFG=' + res.cfg.ablunitConfig.config_uri.fsPath + '='
+	let params = 'CFG=' + res.cfg.ablunitConfig.config_uri.fsPath
 	if (res.cfg.ablunitConfig.dbAliases.length > 0) {
-		params = params + ' ALIASES=' + res.cfg.ablunitConfig.dbAliases.join(';')
+		params = params + '|ALIASES=' + res.cfg.ablunitConfig.dbAliases.join(';')
 	}
 	if (res.cfg.ablunitConfig.optionsUri.updateUri) {
-		params = params + ' ATTR_ABLUNIT_EVENT_FILE=' + res.cfg.ablunitConfig.optionsUri.updateUri.fsPath
+		params = params + '|ATTR_ABLUNIT_EVENT_FILE=' + res.cfg.ablunitConfig.optionsUri.updateUri.fsPath
 	}
 	cmd.push('-param', '"' + params + '"')
 

--- a/src/FileUtils.ts
+++ b/src/FileUtils.ts
@@ -278,3 +278,12 @@ export function getFileModifiedTime (uri: Uri | string): Date {
 
 	return fs.statSync(uri.fsPath).mtime
 }
+
+export function quotePath (path: string) {
+	const sanitized = path.replace(/\\/g, '/')
+	if (sanitized.includes(' ') && !sanitized.startsWith('"') && !sanitized.endsWith('"')) {
+		return '"' + sanitized + '"'
+	}
+	return sanitized
+}
+


### PR DESCRIPTION
## Issue
Running ABLUnit tests fails if any workspace or configuration path contains space characters (e.g., `C:\projects\my test project\`), leading to command-line splitting or parameter truncation.
See #595.

## Solution
1. **Selective Quoting**: Quote path-related command-line arguments (`executable`, `-p`, `-T`, `-pf`, `-profile`) if they contain spaces.
2. **Pipe-Delimited Parameters**: Switched `-param` parameter list delimiter from spaces to pipes (`|`).
3. **Decoupled Parameter Parsing**:
   - Centralized parameter parsing into `VSCode/getSessionParameter.p`.
   - Updated `createDatabaseAliases.p` to accept the parameter string as input instead of directly querying `session:parameter`, facilitating testability.
   - Modified all callers to pass the parameters down.
